### PR TITLE
feat(migrations): add database exec function

### DIFF
--- a/migrations/v0.7/go.mod
+++ b/migrations/v0.7/go.mod
@@ -3,7 +3,7 @@ module github.com/go-vela/community/migrations/v0.7
 go 1.15
 
 require (
-	github.com/go-vela/server v0.7.2
+	github.com/go-vela/server v0.7.3
 	github.com/go-vela/types v0.7.3
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.8.0

--- a/migrations/v0.7/go.sum
+++ b/migrations/v0.7/go.sum
@@ -161,10 +161,9 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-vela/compiler v0.7.2/go.mod h1:cHDJdAps5eln5eAqU0xh8nEQtIUtiSSXot+6g3yBJKc=
-github.com/go-vela/server v0.7.2 h1:Dh0q3Jx3mp7+Db4VdQvLCQxLBycEOz2lEwDBYsNpo3A=
-github.com/go-vela/server v0.7.2/go.mod h1:Y/PzMN4w7GwpJQCuTO3x+AU+jM6GzBQ5jffclUhZ78k=
-github.com/go-vela/types v0.7.2/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
+github.com/go-vela/compiler v0.7.3/go.mod h1:xMVdK2vQML4CyZP5pLXEGt8KuLVXSoT2+nz4laHE8EU=
+github.com/go-vela/server v0.7.3 h1:Bm0Yb4FRsXwpKCNWSOdCQxTMlQKKuSrlfQ4hzZOrkVw=
+github.com/go-vela/server v0.7.3/go.mod h1:whWP0S2SeJ8XZYFnD24QPSIqRi386TYam9UFARz5vdY=
 github.com/go-vela/types v0.7.3 h1:q0gUtl/IKBCxjfHkRSHbYcKBF7FMGVi6m7RAE4ZGGzk=
 github.com/go-vela/types v0.7.3/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -479,7 +478,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -66,5 +66,5 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	return nil
+	return d.Exec()
 }


### PR DESCRIPTION
This adds an `Exec()` function to the `go-vela/community/migrations/v0.7/db` type 👍 

This function will perform the following:

* [Capture a list of all builds](https://github.com/go-vela/server/blob/master/database/build.go#L106-L131) from the database
* Iterate through that list of builds
  * [Capture a list of logs for the build](https://github.com/go-vela/server/blob/master/database/log.go#L17-L56) from the database
  * Iterate through that list of logs
    * [Update log entry](https://github.com/go-vela/server/blob/master/database/log.go#L157-L183) with compression

This utility directly uses the `go-vela/server/database` package, so [we get the compression by calling `UpdateLog()`](https://github.com/go-vela/server/blob/9a01b0a0d9bc38302792237bb457fec6fb51b06f/database/log.go#L170-L176):

```go
	// compress log data for the resource
	//
	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Compress
	err = log.Compress()
	if err != nil {
		return fmt.Errorf("unable to compress logs for step %d: %v", l.GetStepID(), err)
	}
```