### PR TITLE
chore: cleanup Makefile and migration documentation

### DIFF
--- a/migrations/v0.7/DOCS.md
+++ b/migrations/v0.7/DOCS.md
@@ -1,0 +1,130 @@
+# Documentation
+
+This document intends to provide information on how to get the Vela migration utility running locally.
+
+## Prerequisites
+
+* [Golang](https://golang.org/dl/) - for source code and [dependency management](https://github.com/golang/go/wiki/Modules)
+* [Make](https://www.gnu.org/software/make/) - start up local development
+
+## Setup
+
+* Clone this repository to your workstation:
+
+```sh
+# clone the project
+git clone git@github.com:go-vela/community.git $HOME/go-vela/community
+```
+
+* Navigate to the repository code:
+
+```sh
+# change into the project directory
+cd $HOME/go-vela/community/migrations/v0.7
+```
+
+* Set the environment variables for the database driver and configuration string in your local terminal:
+
+```sh
+# set the driver for the Vela database
+export VELA_DATABASE_DRIVER=<database driver from Vela server>
+
+# set the configuration string for the Vela database
+export VELA_DATABASE_CONFIG=<database config from Vela server>
+```
+
+* (OPTIONAL) Set the environment variables for the database connections in your local terminal:
+
+```sh
+# set the total number of open connections for the database
+export VELA_DATABASE_CONNECTION_OPEN=<database connection open from Vela server>
+
+# set the total number of idle connections for the database
+export VELA_DATABASE_CONNECTION_IDLE=<database connection idle from Vela server>
+
+# set the duration for the life of the database connections
+export VELA_DATABASE_CONNECTION_LIFE=<database connection life from Vela server>
+```
+
+## Start
+
+> NOTE: Please review the [setup section](#setup) before moving forward.
+
+This section covers the commands required to get the Vela application running locally.
+
+* Navigate to the repository code:
+
+```sh
+# change into the project directory
+cd $HOME/go-vela/community/migrations/v0.7
+```
+
+### CLI
+
+This method of running the application uses the Golang binary built from the source code.
+
+* Build the Golang binary targeting different operating systems and architectures:
+
+```sh
+# execute the `build` target with `make`
+make build
+
+# This command will output binaries to the following locations:
+#
+# * $HOME/go-vela/community/migrations/v0.7/release/darwin/amd64/vela-migration
+# * $HOME/go-vela/community/migrations/v0.7/release/linux/amd64/vela-migration
+# * $HOME/go-vela/community/migrations/v0.7/release/linux/arm64/vela-migration
+# * $HOME/go-vela/community/migrations/v0.7/release/linux/arm/vela-migration
+# * $HOME/go-vela/community/migrations/v0.7/release/windows/amd64/vela-migration
+```
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration
+```
+
+### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
+
+* Build the Docker image:
+
+```sh
+# execute the `docker-build` target with `make`
+make docker-build
+
+# This command is functionally equivalent to:
+#
+# docker build --no-cache -t target/vela-migration:local .
+```
+
+* Run the Docker image
+
+```sh
+# execute the `run` target with `make`
+make run
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
+#   target/vela-migration:local
+```

--- a/migrations/v0.7/Dockerfile
+++ b/migrations/v0.7/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/go-vela/community
 
 RUN make clean
 
-RUN make build-static
+RUN make build-linux-static
 
 ################################################################################
 ##  docker build --no-cache --target binary -t target/vela-migration:certs .  ##
@@ -30,7 +30,7 @@ RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
 
-COPY --from=binary /opt/go-vela/community/release/vela-migration /bin/vela-migration
+COPY --from=binary /opt/go-vela/community/release/linux/amd64/vela-migration /bin/vela-migration
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 CMD ["/bin/vela-migration"]

--- a/migrations/v0.7/Makefile
+++ b/migrations/v0.7/Makefile
@@ -9,6 +9,20 @@
 .PHONY: clean
 clean: tidy vet fmt fix
 
+# The `build` target is intended to compile
+# the Go source code into a binary.
+#
+# Usage: `make build`
+.PHONY: build
+build: build-darwin build-linux build-windows
+
+# The `build-static` target is intended to compile
+# the Go source code into a statically linked binary.
+#
+# Usage: `make build-static`
+.PHONY: build-static
+build-static: build-darwin-static build-linux-static build-windows-static
+
 # The `tidy` target is intended to clean up
 # the Go module files (go.mod & go.sum).
 #
@@ -49,31 +63,111 @@ fix:
 	@echo "### Fixing Go Code"
 	@go fix ./...
 
-# The `build` target is intended to compile
-# the Go source code into a binary.
+# The `build-darwin` target is intended to compile the
+# Go source code into a Darwin compatible (MacOS) binary.
 #
-# Usage: `make build`
-.PHONY: build
-build:
+# Usage: `make build-darwin`
+.PHONY: build-darwin
+build-darwin:
 	@echo
-	@echo "### Building release/vela-migration binary"
-	GOOS=linux CGO_ENABLED=0 \
+	@echo "### Building release/darwin/amd64/vela-migration binary"
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 \
 		go build -a \
-		-o release/vela-migration \
+		-o release/darwin/amd64/vela-migration \
 		github.com/go-vela/community/migrations/v0.7
 
-# The `build-static` target is intended to compile
-# the Go source code into a statically linked binary.
+# The `build-linux` target is intended to compile the
+# Go source code into a Linux compatible binary.
 #
-# Usage: `make build-static`
-.PHONY: build-static
-build-static:
+# Usage: `make build-linux`
+.PHONY: build-linux
+build-linux:
 	@echo
-	@echo "### Building static release/vela-migration binary"
-	GOOS=linux CGO_ENABLED=0 \
+	@echo "### Building release/linux/amd64/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-o release/linux/amd64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+	@echo
+	@echo "### Building release/linux/arm64/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm64 \
+		go build -a \
+		-o release/linux/arm64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+	@echo
+	@echo "### Building release/linux/arm/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm \
+		go build -a \
+		-o release/linux/arm/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+
+# The `build-windows` target is intended to compile the
+# Go source code into a Windows compatible binary.
+#
+# Usage: `make build-windows`
+.PHONY: build-windows
+build-windows:
+	@echo
+	@echo "### Building release/windows/amd64/vela-migration binary"
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-o release/windows/amd64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+
+# The `build-darwin-static` target is intended to compile the
+# Go source code into a statically linked, Darwin compatible (MacOS) binary.
+#
+# Usage: `make build-darwin-static`
+.PHONY: build-darwin-static
+build-darwin-static:
+	@echo
+	@echo "### Building release/darwin/amd64/vela-migration binary"
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 \
 		go build -a \
 		-ldflags '-s -w -extldflags "-static"' \
-		-o release/vela-migration \
+		-o release/darwin/amd64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+
+# The `build-linux-static` target is intended to compile the
+# Go source code into a statically linked, Linux compatible binary.
+#
+# Usage: `make build-linux-static`
+.PHONY: build-linux-static
+build-linux-static:
+	@echo
+	@echo "### Building release/linux/amd64/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/amd64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+	@echo
+	@echo "### Building release/linux/arm64/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/arm64/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+	@echo
+	@echo "### Building release/linux/arm/vela-migration binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/arm/vela-migration \
+		github.com/go-vela/community/migrations/v0.7
+
+# The `build-windows-static` target is intended to compile the
+# Go source code into a statically linked, Windows compatible binary.
+#
+# Usage: `make build-windows-static`
+.PHONY: build-windows-static
+build-windows-static:
+	@echo
+	@echo "### Building release/windows/amd64/vela-migration binary"
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/windows/amd64/vela-migration \
 		github.com/go-vela/community/migrations/v0.7
 
 # The `build-static-ci` target is intended to compile
@@ -89,3 +183,29 @@ build-static-ci:
 		-ldflags '-s -w -extldflags "-static"' \
 		-o release/vela-migration \
 		github.com/go-vela/community/migrations/v0.7
+
+# The `docker-build` target is intended to build
+# the Docker image for the utility.
+#
+# Usage: `make docker-build`
+.PHONY: docker-build
+docker-build:
+	@echo
+	@echo "### Building target/vela-migration:local image"
+	@docker build --no-cache -t target/vela-migration:local .
+
+# The `docker-run` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run`
+.PHONY: docker-run
+docker-run:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
+		target/vela-migration:local


### PR DESCRIPTION
* Updated the `Makefile` to build Golang binaries for multiple operating systems and architectures
* Updated the `Dockerfile` to account for this
* Added a `DOCS.md` file containing information on how to setup and run the migration utility