### PR TITLE
enhance(v0.7): ignore expected decompress logs from database client

### DIFF
--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -72,16 +72,6 @@ func (d *db) New(c *cli.Context) error {
 func (d *db) Exec() error {
 	logrus.Debug("executing workload from provided configuration")
 
-	// TODO: remove this hack
-	//
-	// this allows us to "ignore" the error messages
-	// returned from GetBuildLogs()
-	//
-	// capture current log level
-	currentLevel := logrus.GetLevel()
-	// only output panic level logs
-	logrus.SetLevel(logrus.PanicLevel)
-
 	logrus.Info("capturing all builds from the database")
 	// capture all builds from the database
 	builds, err := d.Client.GetBuildList()
@@ -89,22 +79,33 @@ func (d *db) Exec() error {
 		return err
 	}
 
-	// TODO: remove this hack
-	//
-	// this allows us to "ignore" the error messages
-	// returned from GetBuildLogs()
-	//
-	// output intended level of logs
-	logrus.SetLevel(currentLevel)
-
 	// iterate through all builds from the database
 	for _, build := range builds {
 		logrus.Infof("capturing all logs for build %d", build.GetID())
+
+		// TODO: remove this hack
+		//
+		// this allows us to "ignore" the error messages
+		// returned from GetBuildLogs()
+		//
+		// capture current log level
+		currentLevel := logrus.GetLevel()
+		// only output panic level logs
+		logrus.SetLevel(logrus.PanicLevel)
+
 		// capture all logs for the build from the database
 		logs, err := d.Client.GetBuildLogs(build.GetID())
 		if err != nil {
 			return err
 		}
+
+		// TODO: remove this hack
+		//
+		// this allows us to "ignore" the error messages
+		// returned from GetBuildLogs()
+		//
+		// output intended level of logs
+		logrus.SetLevel(currentLevel)
 
 		// iterate through all logs for the build from the database
 		for _, log := range logs {

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -72,12 +72,30 @@ func (d *db) New(c *cli.Context) error {
 func (d *db) Exec() error {
 	logrus.Debug("executing workload from provided configuration")
 
+	// TODO: remove this hack
+	//
+	// this allows us to "ignore" the error messages
+	// returned from GetBuildLogs()
+	//
+	// capture current log level
+	currentLevel := logrus.GetLevel()
+	// only output panic level logs
+	logrus.SetLevel(logrus.PanicLevel)
+
 	logrus.Info("capturing all builds from the database")
 	// capture all builds from the database
 	builds, err := d.Client.GetBuildList()
 	if err != nil {
 		return err
 	}
+
+	// TODO: remove this hack
+	//
+	// this allows us to "ignore" the error messages
+	// returned from GetBuildLogs()
+	//
+	// output intended level of logs
+	logrus.SetLevel(currentLevel)
 
 	// iterate through all builds from the database
 	for _, build := range builds {
@@ -97,7 +115,7 @@ func (d *db) Exec() error {
 			}
 		}
 
-		logrus.Infof("all logs updated for build %d", build.GetID())
+		logrus.Debugf("all logs updated for build %d", build.GetID())
 	}
 
 	return nil


### PR DESCRIPTION
Currently, if you run the utility against the database you'll find output like this:

```sh
$ release/darwin/amd64/vela-migration \
  --database.driver postgres \
  --database.config '<config string from server>'

{"level":"info","msg":"capturing all builds from the database","time":"2021-02-22T13:28:05-06:00"}
{"level":"info","msg":"capturing all logs for build 1","time":"2021-02-22T13:28:05-06:00"}
{"level":"error","msg":"unable to decompress logs for build 1: zlib: invalid header","time":"2021-02-22T13:28:05-06:00"}
{"level":"error","msg":"unable to decompress logs for build 1: zlib: invalid header","time":"2021-02-22T13:28:05-06:00"}
{"level":"error","msg":"unable to decompress logs for build 1: zlib: invalid header","time":"2021-02-22T13:28:05-06:00"}
{"level":"info","msg":"all logs updated for build 1","time":"2021-02-22T13:28:05-06:00"}
```

The errors in this output are expected because we're reading logs from the database that haven't been compressed yet.

These errors are [produced from the following code](https://github.com/go-vela/server/blob/9a01b0a0d9bc38302792237bb457fec6fb51b06f/database/log.go#L40-L49):

```go
		// decompress log data for the step
		//
		// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
		err = tmp.Decompress()
		if err != nil {
			// ensures that the change is backwards compatible
			// by logging the error instead of returning it
			// which allows us to fetch uncompressed logs
			logrus.Errorf("unable to decompress logs for build %d: %v", id, err)
		}
```

This change ensures those logs are "hidden" or "ignored" due to them being expected output.