### PR TITLE
docs(v0.7): add unused indexes to drop

### DIFF
--- a/migrations/v0.7/README.md
+++ b/migrations/v0.7/README.md
@@ -4,10 +4,19 @@ _Please note: this notice applies when upgrading to the latest v0.7.x release._
 
 When migrating from Vela version [v0.6.0](https://github.com/go-vela/community/blob/master/releases/v0.6.0.md) to [v0.7.2](https://github.com/go-vela/community/blob/master/releases/v0.7.2.md) the Vela administrator will want to ensure the following actions are being performed:
 
-1. Update tables in the Postgres database
+1. Update tables in the database:
    * `ALTER TABLE users ADD COLUMN IF NOT EXISTS refresh_token VARCHAR(500);`
    * `ALTER TABLE builds ADD COLUMN IF NOT EXISTS deploy_payload VARCHAR(2000);`
    * `ALTER TABLE workers ADD COLUMN IF NOT EXISTS build_limit INTEGER;`
+   * `DROP INDEX IF EXISTS builds_repo_id_number;`
+   * `DROP INDEX IF EXISTS hooks_repo_id_number;`
+   * `DROP INDEX IF EXISTS logs_step_id;`
+   * `DROP INDEX IF EXISTS logs_service_id;`
+   * `DROP INDEX IF EXISTS repos_full_name;`
+   * `DROP INDEX IF EXISTS secrets_type;`
+   * `DROP INDEX IF EXISTS services_build_id_number;`
+   * `DROP INDEX IF EXISTS steps_build_id_number;`
+   * `DROP INDEX IF EXISTS users_name;`
 
 1. Configure the Vela OAuth App's callback (in GitHub) to point to `<vela-server>/authenticate` (do not use the UI for the address)
 


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/301

This updates the documentation to reflect the unused indexes we can drop.

Here is a list of all indexes that would be removed:

* `builds_repo_id_number`
* `hooks_repo_id_number`
* `logs_step_id`
* `logs_service_id`
* `repos_full_name`
* `secrets_type`
* `services_build_id_number`
* `steps_build_id_number`
* `users_name`