### PR TITLE
enhance(v0.7): add logic to perform table alterations

### DIFF
--- a/migrations/v0.7/alter.go
+++ b/migrations/v0.7/alter.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-vela/types/constants"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	AlterBuilds = `
+ALTER TABLE builds
+ADD COLUMN IF NOT EXISTS
+deploy_payload VARCHAR(2000);
+`
+
+	AlterUsers = `
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS
+refresh_token VARCHAR(500);
+`
+
+	AlterWorkers = `
+ALTER TABLE workers
+ADD COLUMN IF NOT EXISTS
+build_limit INTEGER;
+`
+)
+
+// Alter will run a series of ALTER statements against the
+// database to modify the tables that require new or
+// modified columns.
+func (d *db) Alter() error {
+	logrus.Debug("executing alter from provided configuration")
+
+	// create a fresh database client
+	//
+	// This will allow us to manually run SQL statements
+	// against the database.
+	_database, err := gorm.Open(d.Driver, d.Config)
+	if err != nil {
+		return err
+	}
+	defer _database.Close()
+
+	logrus.Infof("altering %s table to add deploy_payload column", constants.TableBuild)
+	// alter the builds table to add the deploy_payload column
+	_, err = _database.DB().Exec(AlterBuilds)
+	if err != nil {
+		return fmt.Errorf("unable to alter %s table: %v", constants.TableBuild, err)
+	}
+
+	logrus.Infof("altering %s table to add refresh_token column", constants.TableUser)
+	// alter the users table to add the refresh_token column
+	_, err = _database.DB().Exec(AlterUsers)
+	if err != nil {
+		return fmt.Errorf("unable to alter %s table: %v", constants.TableUser, err)
+	}
+
+	logrus.Infof("altering %s table to add build_limit column", constants.TableWorker)
+	// alter the workers table to add the build_limit column
+	_, err = _database.DB().Exec(AlterWorkers)
+	if err != nil {
+		return fmt.Errorf("unable to alter %s table: %v", constants.TableWorker, err)
+	}
+
+	return nil
+}

--- a/migrations/v0.7/compress.go
+++ b/migrations/v0.7/compress.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-vela/server/database"
+	"github.com/go-vela/types/constants"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+// Compress attempts to capture all builds from the database.
+// The function will then iterate through the list of builds
+// and capture all logs for each build. Then, the function
+// will iterate through each log for the build and update
+// the log entry with compressed data.
+func (d *db) Compress() error {
+	logrus.Debug("executing compress from provided configuration")
+
+	logrus.Info("capturing all builds from the database")
+	// capture all builds from the database
+	builds, err := d.Client.GetBuildList()
+	if err != nil {
+		return err
+	}
+
+	// iterate through all builds from the database
+	for _, build := range builds {
+		logrus.Infof("capturing all logs for build %d", build.GetID())
+
+		// TODO: remove this hack
+		//
+		// this allows us to "ignore" the error messages
+		// returned from GetBuildLogs()
+		//
+		// capture current log level
+		currentLevel := logrus.GetLevel()
+		// only output panic level logs
+		logrus.SetLevel(logrus.PanicLevel)
+
+		// capture all logs for the build from the database
+		logs, err := d.Client.GetBuildLogs(build.GetID())
+		if err != nil {
+			return err
+		}
+
+		// TODO: remove this hack
+		//
+		// this allows us to "ignore" the error messages
+		// returned from GetBuildLogs()
+		//
+		// output intended level of logs
+		logrus.SetLevel(currentLevel)
+
+		// iterate through all logs for the build from the database
+		for _, log := range logs {
+			// update log entry with compression in the database
+			err = d.Client.UpdateLog(log)
+			if err != nil {
+				return err
+			}
+		}
+
+		logrus.Debugf("all logs updated for build %d", build.GetID())
+	}
+
+	return nil
+}

--- a/migrations/v0.7/compress.go
+++ b/migrations/v0.7/compress.go
@@ -5,14 +5,7 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
-
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
 )
 
 // Compress attempts to capture all builds from the database.

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -66,57 +66,15 @@ func (d *db) New(c *cli.Context) error {
 }
 
 // Exec takes the provided configuration and attempts to
-// capture all logs from the database. After capturing all
-// logs from the database, we'll update the log entry with
-// a compressed data field.
+// run a series of different functions that will
+// manipulate indexes, tables and columns.
 func (d *db) Exec() error {
 	logrus.Debug("executing workload from provided configuration")
 
-	logrus.Info("capturing all builds from the database")
-	// capture all builds from the database
-	builds, err := d.Client.GetBuildList()
+	// compress all log entries in the database
+	err := d.Compress()
 	if err != nil {
 		return err
-	}
-
-	// iterate through all builds from the database
-	for _, build := range builds {
-		logrus.Infof("capturing all logs for build %d", build.GetID())
-
-		// TODO: remove this hack
-		//
-		// this allows us to "ignore" the error messages
-		// returned from GetBuildLogs()
-		//
-		// capture current log level
-		currentLevel := logrus.GetLevel()
-		// only output panic level logs
-		logrus.SetLevel(logrus.PanicLevel)
-
-		// capture all logs for the build from the database
-		logs, err := d.Client.GetBuildLogs(build.GetID())
-		if err != nil {
-			return err
-		}
-
-		// TODO: remove this hack
-		//
-		// this allows us to "ignore" the error messages
-		// returned from GetBuildLogs()
-		//
-		// output intended level of logs
-		logrus.SetLevel(currentLevel)
-
-		// iterate through all logs for the build from the database
-		for _, log := range logs {
-			// update log entry with compression in the database
-			err = d.Client.UpdateLog(log)
-			if err != nil {
-				return err
-			}
-		}
-
-		logrus.Debugf("all logs updated for build %d", build.GetID())
 	}
 
 	return nil

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -68,11 +68,23 @@ func (d *db) New(c *cli.Context) error {
 // Exec takes the provided configuration and attempts to
 // run a series of different functions that will
 // manipulate indexes, tables and columns.
-func (d *db) Exec() error {
+func (d *db) Exec(c *cli.Context) error {
 	logrus.Debug("executing workload from provided configuration")
 
+	// alter all tables in the database
+	err := d.Alter()
+	if err != nil {
+		return err
+	}
+
+	// create new database service
+	err = d.New(c)
+	if err != nil {
+		return err
+	}
+
 	// compress all log entries in the database
-	err := d.Compress()
+	err = d.Compress()
 	if err != nil {
 		return err
 	}

--- a/migrations/v0.7/go.mod
+++ b/migrations/v0.7/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/go-vela/server v0.7.3
 	github.com/go-vela/types v0.7.3
+	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.8.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -60,11 +60,5 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	// create database configuration
-	err = d.New(c)
-	if err != nil {
-		return err
-	}
-
-	return d.Exec()
+	return d.Exec(c)
 }


### PR DESCRIPTION
This adds logic to execute the `ALTER` statements documented in the `README.md` for this utility.

https://github.com/go-vela/community/blob/master/migrations/v0.7/README.md

The following `ALTER` statements would be executed:

* `ALTER TABLE builds ADD COLUMN IF NOT EXISTS deploy_payload VARCHAR(2000);`
* `ALTER TABLE users ADD COLUMN IF NOT EXISTS refresh_token VARCHAR(500);`
* `ALTER TABLE workers ADD COLUMN IF NOT EXISTS build_limit INTEGER;`