### PR TITLE
feat(v0.7): concurrently compress build logs

### DIFF
--- a/migrations/v0.7/compress.go
+++ b/migrations/v0.7/compress.go
@@ -5,7 +5,11 @@
 package main
 
 import (
+	"github.com/go-vela/types/library"
+
 	"github.com/sirupsen/logrus"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Compress attempts to capture all builds from the database.
@@ -23,33 +27,58 @@ func (d *db) Compress() error {
 		return err
 	}
 
+	// create new wait group to compress build logs concurrently
+	group := new(errgroup.Group)
+	// create new channel to process build logs concurrently
+	buildChannel := make(chan *library.Build)
+
+	// add set limit of routines to errgroup
+	// and begin processing build logs
+	for i := 0; i < d.ConcurrencyLimit; i++ {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := i
+
+		// spawn a goroutine to begin compressing build
+		// logs that are published to the channel
+		group.Go(func() error {
+			return d.CompressBuildLogs(tmp, buildChannel)
+		})
+	}
+
 	// iterate through all builds from the database
 	for _, build := range builds {
-		logrus.Infof("capturing all logs for build %d", build.GetID())
+		logrus.Infof("publishing build %d to channel", build.GetID())
 
-		// TODO: remove this hack
-		//
-		// this allows us to "ignore" the error messages
-		// returned from GetBuildLogs()
-		//
-		// capture current log level
-		currentLevel := logrus.GetLevel()
-		// only output panic level logs
-		logrus.SetLevel(logrus.PanicLevel)
+		// publish the build to the channel
+		buildChannel <- build
+
+		logrus.Debugf("build %d published to channel", build.GetID())
+	}
+
+	logrus.Debug("closing channel for publishing builds")
+
+	// close channel to signal goroutines to stop processing
+	close(buildChannel)
+
+	logrus.Debug("waiting for goroutines to complete")
+
+	return group.Wait()
+}
+
+func (d *db) CompressBuildLogs(index int, buildChannel chan *library.Build) error {
+	logrus.Infof("thread %d: listening on build channel", index)
+
+	// iterate through all builds published to the channel
+	for b := range buildChannel {
+		logrus.Infof("thread %d: capturing all logs for build %d", index, b.GetID())
 
 		// capture all logs for the build from the database
-		logs, err := d.Client.GetBuildLogs(build.GetID())
+		logs, err := d.Client.GetBuildLogs(b.GetID())
 		if err != nil {
 			return err
 		}
 
-		// TODO: remove this hack
-		//
-		// this allows us to "ignore" the error messages
-		// returned from GetBuildLogs()
-		//
-		// output intended level of logs
-		logrus.SetLevel(currentLevel)
+		logrus.Infof("thread %d: compressing all logs for build %d", index, b.GetID())
 
 		// iterate through all logs for the build from the database
 		for _, log := range logs {
@@ -60,8 +89,10 @@ func (d *db) Compress() error {
 			}
 		}
 
-		logrus.Debugf("all logs updated for build %d", build.GetID())
+		logrus.Debugf("thread %d: all logs compressed for build %d", index, b.GetID())
 	}
+
+	logrus.Infof("thread %d: shutting down", index)
 
 	return nil
 }

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -28,9 +28,10 @@ type connection struct {
 // information used to communicate
 // with the database.
 type db struct {
-	Driver     string
-	Config     string
-	Connection *connection
+	Driver           string
+	Config           string
+	Connection       *connection
+	ConcurrencyLimit int
 
 	Client database.Service
 }

--- a/migrations/v0.7/go.mod
+++ b/migrations/v0.7/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.8.0
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/migrations/v0.7/go.sum
+++ b/migrations/v0.7/go.sum
@@ -622,6 +622,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/migrations/v0.7/main.go
+++ b/migrations/v0.7/main.go
@@ -40,6 +40,13 @@ func main() {
 
 	app.Flags = []cli.Flag{
 
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_CONCURRENCY_LIMIT", "CONCURRENCY_LIMIT"},
+			Name:    "concurrency.limit",
+			Usage:   "sets the number of concurrent processes running",
+			Value:   4,
+		},
+
 		// Database Flags
 
 		&cli.StringFlag{

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -45,8 +45,9 @@ func run(c *cli.Context) error {
 
 	// create database object
 	d := &db{
-		Driver: c.String("database.driver"),
-		Config: c.String("database.config"),
+		Driver:           c.String("database.driver"),
+		Config:           c.String("database.config"),
+		ConcurrencyLimit: c.Int("concurrency.limit"),
 		Connection: &connection{
 			Idle: c.Int("database.connection.open"),
 			Life: c.Duration("database.connection.idle"),


### PR DESCRIPTION
We ran the currently utility against our lower environment to get a feel for how long things might take for production.

Unfortunately, it took ~ `2` hours to compress logs for ~ `35k` builds.

This enables the utility to concurrently compress build logs stored in the database.

This can be set via the flag `concurrency.limit` or environment variables:

* `VELA_CONCURRENCY_LIMIT`
* `CONCURRENCY_LIMIT`

The default concurrency limit is set to `4` to help speed things up while being mindful of the underlying system.

This also has an added benefit of being able to "turn off" concurrency by passing a limit of `1`.