### PR TITLE
feat(v0.7): skip builds meeting certain criteria

### DIFF
--- a/migrations/v0.7/DOCS.md
+++ b/migrations/v0.7/DOCS.md
@@ -36,14 +36,20 @@ export VELA_DATABASE_CONFIG=<database config from Vela server>
 * (OPTIONAL) Set the environment variables for the database connections in your local terminal:
 
 ```sh
-# set the total number of open connections for the database
+# set the total number of open connections for the database (default: 0 - no limit)
 export VELA_DATABASE_CONNECTION_OPEN=<database connection open from Vela server>
 
-# set the total number of idle connections for the database
+# set the total number of idle connections for the database (default: 2)
 export VELA_DATABASE_CONNECTION_IDLE=<database connection idle from Vela server>
 
-# set the duration for the life of the database connections
+# set the duration for the life of the database connections (default: 30m)
 export VELA_DATABASE_CONNECTION_LIFE=<database connection life from Vela server>
+
+# sets the limit of build records to compress in the database (default: 0 - no limit)
+export VELA_BUILD_LIMIT=<maximum build id to attempt to compress logs>
+
+# sets the limit of concurrent processes used to operate on the database (default: 4)
+export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
 ```
 
 ## Start
@@ -121,6 +127,8 @@ make run
 # This command is functionally equivalent to:
 #
 # docker run --rm \
+#   -e VELA_BUILD_LIMIT \
+#   -e VELA_CONCURRENCY_LIMIT \
 #   -e VELA_DATABASE_DRIVER \
 #   -e VELA_DATABASE_CONFIG \
 #   -e VELA_DATABASE_CONNECTION_OPEN \

--- a/migrations/v0.7/Makefile
+++ b/migrations/v0.7/Makefile
@@ -203,6 +203,8 @@ docker-run:
 	@echo
 	@echo "### Executing target/vela-migration:local image"
 	@docker run --rm \
+		-e VELA_BUILD_LIMIT \
+		-e VELA_CONCURRENCY_LIMIT \
 		-e VELA_DATABASE_DRIVER \
 		-e VELA_DATABASE_CONFIG \
 		-e VELA_DATABASE_CONNECTION_OPEN \

--- a/migrations/v0.7/compress.go
+++ b/migrations/v0.7/compress.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 
 	"github.com/sirupsen/logrus"
@@ -47,6 +48,25 @@ func (d *db) Compress() error {
 
 	// iterate through all builds from the database
 	for _, build := range builds {
+		// handle the build based off the id provided
+		if d.BuildLimit > 0 && build.GetID() > int64(d.BuildLimit) {
+			logrus.Tracef("build %d is greater than threshold %d - skipping", build.GetID(), d.BuildLimit)
+
+			continue
+		}
+
+		// handle the build based off the status provided
+		switch build.GetStatus() {
+		// build is in a pending state
+		case constants.StatusPending:
+			fallthrough
+		// build is in a running state
+		case constants.StatusRunning:
+			logrus.Tracef("build %d has a status of %s - skipping", build.GetID(), build.GetStatus())
+
+			continue
+		}
+
 		logrus.Infof("publishing build %d to channel", build.GetID())
 
 		// publish the build to the channel

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -28,9 +28,11 @@ type connection struct {
 // information used to communicate
 // with the database.
 type db struct {
-	Driver           string
-	Config           string
-	Connection       *connection
+	Driver     string
+	Config     string
+	Connection *connection
+
+	BuildLimit       int
 	ConcurrencyLimit int
 
 	Client database.Service
@@ -111,6 +113,16 @@ func (d *db) Validate() error {
 	// check if the database configuration is set
 	if len(d.Config) == 0 {
 		return fmt.Errorf("VELA_DATABASE_CONFIG is not properly configured")
+	}
+
+	// check if the database build limit is set
+	if d.BuildLimit < 0 {
+		return fmt.Errorf("VELA_BUILD_LIMIT is not properly configured")
+	}
+
+	// check if the database concurrency limit is set
+	if d.ConcurrencyLimit < 1 {
+		return fmt.Errorf("VELA_CONCURRENCY_LIMIT is not properly configured")
 	}
 
 	return nil

--- a/migrations/v0.7/main.go
+++ b/migrations/v0.7/main.go
@@ -41,6 +41,12 @@ func main() {
 	app.Flags = []cli.Flag{
 
 		&cli.IntFlag{
+			EnvVars: []string{"VELA_BUILD_LIMIT", "BUILD_LIMIT"},
+			Name:    "build.limit",
+			Usage:   "sets the limit of build records to compress",
+			Value:   0,
+		},
+		&cli.IntFlag{
 			EnvVars: []string{"VELA_CONCURRENCY_LIMIT", "CONCURRENCY_LIMIT"},
 			Name:    "concurrency.limit",
 			Usage:   "sets the number of concurrent processes running",

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -47,6 +47,7 @@ func run(c *cli.Context) error {
 	d := &db{
 		Driver:           c.String("database.driver"),
 		Config:           c.String("database.config"),
+		BuildLimit:       c.Int("build.limit"),
 		ConcurrencyLimit: c.Int("concurrency.limit"),
 		Connection: &connection{
 			Idle: c.Int("database.connection.open"),


### PR DESCRIPTION
This enables the utility to skip compressing logs for certain builds that meet the defined criteria in the database.

## Status

The first set of criteria is specifically looking at the `status` field for a build.

If a build is in a `pending` or `running` status, we can reasonably assume the build is going to run or is running.

We don't want to corrupt the logs data for builds in those states so we ignore compressing the logs for them.

## ID

The second set of criteria is specifically looking at the `id` field for a build.

When upgrading to the latest release, you'll have log data stored in the database in a compressed state.

In order to help improve efficiency, we've added a variable that you can configure to ignore builds with a specific `id`.

This can be set via the flag `build.limit` or environment variables:

* `VELA_BUILD_LIMIT`
* `BUILD_LIMIT`

The default build limit is set to `0` to ensure all build logs in the system are compressed.

However, you can set that to a matching `id` from the `builds` table and the utility will not compress any logs for a build that has an `id` greater than the one you specified as the limit.