### PR TITLE
feat(v0.7): add logic to concurrently encrypt secrets

### DIFF
--- a/migrations/v0.7/compress.go
+++ b/migrations/v0.7/compress.go
@@ -28,7 +28,7 @@ func (d *db) Compress() error {
 		return err
 	}
 
-	// create new wait group to compress build logs concurrently
+	// create new error group to compress build logs concurrently
 	group := new(errgroup.Group)
 	// create new channel to process build logs concurrently
 	buildChannel := make(chan *library.Build)
@@ -50,7 +50,7 @@ func (d *db) Compress() error {
 	for _, build := range builds {
 		// handle the build based off the id provided
 		if d.BuildLimit > 0 && build.GetID() > int64(d.BuildLimit) {
-			logrus.Tracef("build %d is greater than threshold %d - skipping", build.GetID(), d.BuildLimit)
+			logrus.Tracef("build %d is greater than limit %d - skipping", build.GetID(), d.BuildLimit)
 
 			continue
 		}
@@ -112,7 +112,7 @@ func (d *db) CompressBuildLogs(index int, buildChannel chan *library.Build) erro
 		logrus.Debugf("thread %d: all logs compressed for build %d", index, b.GetID())
 	}
 
-	logrus.Infof("thread %d: shutting down", index)
+	logrus.Infof("thread %d: shutting down on build channel", index)
 
 	return nil
 }

--- a/migrations/v0.7/database.go
+++ b/migrations/v0.7/database.go
@@ -28,12 +28,14 @@ type connection struct {
 // information used to communicate
 // with the database.
 type db struct {
-	Driver     string
-	Config     string
-	Connection *connection
+	Driver        string
+	Config        string
+	Connection    *connection
+	EncryptionKey string
 
 	BuildLimit       int
 	ConcurrencyLimit int
+	SecretLimit      int
 
 	Client database.Service
 }
@@ -98,6 +100,12 @@ func (d *db) Exec(c *cli.Context) error {
 		return err
 	}
 
+	// encrypt all secret values in the database
+	err = d.Encrypt()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -115,6 +123,13 @@ func (d *db) Validate() error {
 		return fmt.Errorf("VELA_DATABASE_CONFIG is not properly configured")
 	}
 
+	// enforce AES-256, so check explicitly for 32 bytes on the key
+	//
+	// nolint: gomnd // ignore magic number
+	if len(d.EncryptionKey) != 32 {
+		return fmt.Errorf("VELA_DATABASE_ENCRYPTION_KEY invalid length specified: %d", len(d.EncryptionKey))
+	}
+
 	// check if the database build limit is set
 	if d.BuildLimit < 0 {
 		return fmt.Errorf("VELA_BUILD_LIMIT is not properly configured")
@@ -123,6 +138,11 @@ func (d *db) Validate() error {
 	// check if the database concurrency limit is set
 	if d.ConcurrencyLimit < 1 {
 		return fmt.Errorf("VELA_CONCURRENCY_LIMIT is not properly configured")
+	}
+
+	// check if the database secret limit is set
+	if d.SecretLimit < 0 {
+		return fmt.Errorf("VELA_SECRET_LIMIT is not properly configured")
 	}
 
 	return nil

--- a/migrations/v0.7/encrypt.go
+++ b/migrations/v0.7/encrypt.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Encrypt does stuff...
+func (d *db) Encrypt() error {
+	logrus.Debug("executing encrypt from provided configuration")
+
+	logrus.Info("capturing all secrets from the database")
+	// capture all secrets from the database
+	secrets, err := d.Client.GetSecretList()
+	if err != nil {
+		return err
+	}
+
+	// create new error group to encrypt secret values concurrently
+	group := new(errgroup.Group)
+	// create new channel to process secrets concurrently
+	secretChannel := make(chan *library.Secret)
+
+	// add set limit of routines to errgroup
+	// and begin processing secrets
+	for i := 0; i < d.ConcurrencyLimit; i++ {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := i
+
+		// spawn a goroutine to begin encrypting secret
+		// values that are published to the channel
+		group.Go(func() error {
+			return d.EncryptSecrets(tmp, secretChannel)
+		})
+	}
+
+	// iterate through all secrets from the database
+	for _, secret := range secrets {
+		// handle the secret based off the id provided
+		if d.SecretLimit > 0 && secret.GetID() > int64(d.SecretLimit) {
+			logrus.Tracef("secret %d is greater than limit %d - skipping", secret.GetID(), d.SecretLimit)
+
+			continue
+		}
+
+		logrus.Infof("publishing secret %d to channel", secret.GetID())
+
+		// publish the secret to the channel
+		secretChannel <- secret
+
+		logrus.Debugf("secret %d published to channel", secret.GetID())
+	}
+
+	logrus.Debug("closing channel for publishing secrets")
+
+	// close channel to signal goroutines to stop processing
+	close(secretChannel)
+
+	logrus.Debug("waiting for goroutines to complete")
+
+	return group.Wait()
+}
+
+func (d *db) EncryptSecrets(index int, secretChannel chan *library.Secret) error {
+	logrus.Infof("thread %d: listening on secret channel", index)
+
+	// iterate through all secrets published to the channel
+	for s := range secretChannel {
+		logrus.Infof("thread %d: encrypting the value for secret %d", index, s.GetID())
+
+		// update secret with encryption in the database
+		err := d.Client.UpdateSecret(s)
+		if err != nil {
+			return err
+		}
+
+		logrus.Debugf("thread %d: value encrypted for secret %d", index, s.GetID())
+	}
+
+	logrus.Infof("thread %d: shutting down on secret channel", index)
+
+	return nil
+}

--- a/migrations/v0.7/go.mod
+++ b/migrations/v0.7/go.mod
@@ -2,13 +2,9 @@ module github.com/go-vela/community/migrations/v0.7
 
 go 1.15
 
-replace github.com/go-vela/server => ../../../server
-
-replace github.com/go-vela/types => ../../../types
-
 require (
-	github.com/go-vela/server v0.7.4-0.20210303185711-50f95627553c
-	github.com/go-vela/types v0.7.4-0.20210225205732-6bf075d597f6
+	github.com/go-vela/server v0.7.4-0.20210305192218-c039b1c7d097
+	github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df
 	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.8.0

--- a/migrations/v0.7/go.mod
+++ b/migrations/v0.7/go.mod
@@ -2,9 +2,13 @@ module github.com/go-vela/community/migrations/v0.7
 
 go 1.15
 
+replace github.com/go-vela/server => ../../../server
+
+replace github.com/go-vela/types => ../../../types
+
 require (
-	github.com/go-vela/server v0.7.3
-	github.com/go-vela/types v0.7.3
+	github.com/go-vela/server v0.7.4-0.20210303185711-50f95627553c
+	github.com/go-vela/types v0.7.4-0.20210225205732-6bf075d597f6
 	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.8.0

--- a/migrations/v0.7/go.sum
+++ b/migrations/v0.7/go.sum
@@ -160,10 +160,6 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.3/go.mod h1:xMVdK2vQML4CyZP5pLXEGt8KuLVXSoT2+nz4laHE8EU=
-github.com/go-vela/server v0.7.3 h1:Bm0Yb4FRsXwpKCNWSOdCQxTMlQKKuSrlfQ4hzZOrkVw=
-github.com/go-vela/server v0.7.3/go.mod h1:whWP0S2SeJ8XZYFnD24QPSIqRi386TYam9UFARz5vdY=
-github.com/go-vela/types v0.7.3 h1:q0gUtl/IKBCxjfHkRSHbYcKBF7FMGVi6m7RAE4ZGGzk=
-github.com/go-vela/types v0.7.3/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -615,6 +611,7 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210126194326-f9ce19ea3013/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/migrations/v0.7/go.sum
+++ b/migrations/v0.7/go.sum
@@ -160,6 +160,11 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.3/go.mod h1:xMVdK2vQML4CyZP5pLXEGt8KuLVXSoT2+nz4laHE8EU=
+github.com/go-vela/server v0.7.4-0.20210305192218-c039b1c7d097 h1:x0X9FBL9bGx4p9/vviRcDI5CBlDJipm4xFjA9f/ftns=
+github.com/go-vela/server v0.7.4-0.20210305192218-c039b1c7d097/go.mod h1:W+L8Te2y5FnjvT++B9ufdyFy1HooiBNkssvcJSQ1o18=
+github.com/go-vela/types v0.7.3/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
+github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df h1:7/PTAJmn1LPXrftKbxQPsIKKa6UgY7/cBmFcbr4q6Pw=
+github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/migrations/v0.7/main.go
+++ b/migrations/v0.7/main.go
@@ -52,6 +52,12 @@ func main() {
 			Usage:   "sets the number of concurrent processes running",
 			Value:   4,
 		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_SECRET_LIMIT", "SECRET_LIMIT"},
+			Name:    "secret.limit",
+			Usage:   "sets the limit of secret records to encrypt",
+			Value:   0,
+		},
 
 		// Database Flags
 
@@ -84,6 +90,11 @@ func main() {
 			Name:    "database.connection.life",
 			Usage:   "sets the amount of time a connection may be reused for the database",
 			Value:   30 * time.Minute,
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
+			Name:    "database.encryption.key",
+			Usage:   "AES-256 key for encrypting and decrypting values",
 		},
 
 		// Logger Flags

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -47,8 +47,10 @@ func run(c *cli.Context) error {
 	d := &db{
 		Driver:           c.String("database.driver"),
 		Config:           c.String("database.config"),
+		EncryptionKey:    c.String("database.encryption.key"),
 		BuildLimit:       c.Int("build.limit"),
 		ConcurrencyLimit: c.Int("concurrency.limit"),
+		SecretLimit:      c.Int("secret.limit"),
 		Connection: &connection{
 			Idle: c.Int("database.connection.open"),
 			Life: c.Duration("database.connection.idle"),


### PR DESCRIPTION
Dependent on https://github.com/go-vela/server/pull/304

When upgrading to the latest release, you'll have secret values stored in the database in an encrypted state.

This enables the utility to concurrently encrypt secret values stored in the database.

This can be set via the existing flag `concurrency.limit` or environment variables:

* `VELA_CONCURRENCY_LIMIT`
* `CONCURRENCY_LIMIT`

The default concurrency limit is still set to `4`.

This also has an added benefit of being able to "turn off" concurrency by passing a limit of `1`.

Also, in order to help improve efficiency, we've added a variable that you can configure to ignore secrets with a specific `id`.

This can be set via the flag `secret.limit` or environment variables:

* `VELA_SECRET_LIMIT`
* `SECRET_LIMIT`

The default secret limit is set to `0` to ensure all secrets in the system are encrypted.

However, you can set that to a matching `id` from the `secrets` table and the utility will not encrypt any secrets that has an `id` greater than the one you specified as the limit.
