### PR TITLE
Fix readme's broken link to documents

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,13 +14,13 @@ Copyright (c) 2020 Target Brands, Inc.
 
 A collection of potential new features or modifications to be made to the product.
 
-Please see our [proposals documentation](proposals/README.md) documentation for more information.
+Please see our [proposals documentation](../proposals/README.md) documentation for more information.
 
 ## Releases
 
 A collection of records (a.k.a. release notes) detailing the new features or modifications made to the product.
 
-Please see our [releases documentation](releases/README.md) documentation for more information.
+Please see our [releases documentation](../releases/README.md) documentation for more information.
 
 ## License
 


### PR DESCRIPTION
## What
I found that the links are broken on `README` because the path specified were wrong. Corrected.