### PR TITLE
feat(v0.7): add action flags to invoke specific operations

### DIFF
--- a/migrations/v0.7/DOCS.md
+++ b/migrations/v0.7/DOCS.md
@@ -47,21 +47,6 @@ export VELA_DATABASE_CONNECTION_IDLE=<database connection idle from Vela server>
 
 # set the duration for the life of the database connections (default: 30m)
 export VELA_DATABASE_CONNECTION_LIFE=<database connection life from Vela server>
-
-# set the level of compression for the log entries (default: 3)
-export VELA_DATABASE_COMPRESSION_LEVEL=<database compression level from Vela server>
-
-# set the key to encrypt secret values with AES-256
-export VELA_DATABASE_ENCRYPTION_KEY=<database encryption key from Vela server>
-
-# sets the limit of build records to compress logs for in the database (default: 0 - no limit)
-export VELA_BUILD_LIMIT=<maximum build id to attempt to compress logs>
-
-# sets the limit of concurrent processes used to operate on the database (default: 4)
-export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
-
-# sets the limit of secret records to encrypt values for in the database (default: 0 - no limit)
-export VELA_SECRET_LIMIT=<maximum secret id to attempt to encrypt value>
 ```
 
 ## Start
@@ -148,6 +133,222 @@ make run
 #   -e VELA_DATABASE_CONNECTION_IDLE \
 #   -e VELA_DATABASE_CONNECTION_LIFE \
 #   -e VELA_DATABASE_COMPRESSION_LEVEL \
+#   -e VELA_DATABASE_ENCRYPTION_KEY \
+#   target/vela-migration:local
+```
+
+## Usage
+
+> NOTE: Please review the [start section](#start) before moving forward.
+
+This utility supports invoking the following actions when migrating to `v0.7.x`:
+
+* `all` - run all supported actions configured in the migration utility
+* `alter.tables` - runs the action responsible for altering database tables
+* `compress.logs` - runs the action responsible for compressing all logs
+* `drop.indexes` - runs the action responsible for dropping unused indexes
+* `encrypt.secrets` - runs the action responsible for encrypting secret values
+
+### Alter Tables
+
+#### CLI
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration --alter.tables
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration --alter.tables
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration --alter.tables
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration --alter.tables
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration --alter.tables
+```
+
+#### Docker
+
+* Run the Docker image
+
+```sh
+# execute the `run-alter` target with `make`
+make run-alter
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_ALTER_TABLES=true \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
+#   target/vela-migration:local
+```
+
+### Compress Logs
+
+* Set the environment variables for the database configuration in your local terminal:
+
+```sh
+# (optional) sets the limit of build records to compress logs for in the database (default: 0)
+export VELA_BUILD_LIMIT=<maximum build id to attempt to compress logs>
+
+# sets the limit of concurrent processes used to operate on the database (default: 4)
+export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
+
+# set the level of compression for the log entries (default: 3)
+export VELA_DATABASE_COMPRESSION_LEVEL=<database compression level from Vela server>
+```
+
+#### CLI
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration --compress.logs
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration --compress.logs
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration --compress.logs
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration --compress.logs
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration --compress.logs
+```
+
+#### Docker
+
+* Run the Docker image
+
+```sh
+# execute the `run-compress` target with `make`
+make run-compress
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_COMPRESS_LOGS=true \
+#   -e VELA_BUILD_LIMIT \
+#   -e VELA_CONCURRENCY_LIMIT \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
+#   -e VELA_DATABASE_COMPRESSION_LEVEL \
+#   target/vela-migration:local
+```
+
+### Drop Indexes
+
+#### CLI
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration --drop.indexes
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration --drop.indexes
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration --drop.indexes
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration --drop.indexes
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration --drop.indexes
+```
+
+#### Docker
+
+* Run the Docker image
+
+```sh
+# execute the `run-drop` target with `make`
+make run-drop
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_DROP_INDEXES=true \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
+#   target/vela-migration:local
+```
+
+### Encrypt Secrets
+
+* Set the environment variables for the other database configuration in your local terminal:
+
+```sh
+# sets the limit of concurrent processes used to operate on the database (default: 4)
+export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
+
+# set the key to encrypt secret values with AES-256
+export VELA_DATABASE_ENCRYPTION_KEY=<database encryption key from Vela server>
+
+# (optional) sets the limit of secret records to encrypt values for in the database (default: 0)
+export VELA_SECRET_LIMIT=<maximum secret id to attempt to encrypt value>
+```
+
+#### CLI
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration --encrypt.secrets
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration --encrypt.secrets
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration --encrypt.secrets
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration --encrypt.secrets
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration --encrypt.secrets
+```
+
+#### Docker
+
+* Run the Docker image
+
+```sh
+# execute the `run-encrypt` target with `make`
+make run-encrypt
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_ENCRYPT_SECRETS=true \
+#   -e VELA_SECRETS_LIMIT \
+#   -e VELA_CONCURRENCY_LIMIT \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
 #   -e VELA_DATABASE_ENCRYPTION_KEY \
 #   target/vela-migration:local
 ```

--- a/migrations/v0.7/DOCS.md
+++ b/migrations/v0.7/DOCS.md
@@ -153,6 +153,8 @@ This utility supports invoking the following actions when migrating to `v0.7.x`:
 
 #### CLI
 
+This method of running the application uses the Golang binary built from the source code.
+
 * Run the Golang binary for the specific operating system and architecture:
 
 ```sh
@@ -173,6 +175,8 @@ release/windows/amd64/vela-migration --alter.tables
 ```
 
 #### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
 
 * Run the Docker image
 
@@ -209,6 +213,8 @@ export VELA_DATABASE_COMPRESSION_LEVEL=<database compression level from Vela ser
 
 #### CLI
 
+This method of running the application uses the Golang binary built from the source code.
+
 * Run the Golang binary for the specific operating system and architecture:
 
 ```sh
@@ -229,6 +235,8 @@ release/windows/amd64/vela-migration --compress.logs
 ```
 
 #### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
 
 * Run the Docker image
 
@@ -255,6 +263,8 @@ make run-compress
 
 #### CLI
 
+This method of running the application uses the Golang binary built from the source code.
+
 * Run the Golang binary for the specific operating system and architecture:
 
 ```sh
@@ -275,6 +285,8 @@ release/windows/amd64/vela-migration --drop.indexes
 ```
 
 #### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
 
 * Run the Docker image
 
@@ -311,6 +323,8 @@ export VELA_SECRET_LIMIT=<maximum secret id to attempt to encrypt value>
 
 #### CLI
 
+This method of running the application uses the Golang binary built from the source code.
+
 * Run the Golang binary for the specific operating system and architecture:
 
 ```sh
@@ -331,6 +345,8 @@ release/windows/amd64/vela-migration --encrypt.secrets
 ```
 
 #### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
 
 * Run the Docker image
 

--- a/migrations/v0.7/Makefile
+++ b/migrations/v0.7/Makefile
@@ -23,6 +23,41 @@ build: build-darwin build-linux build-windows
 .PHONY: build-static
 build-static: build-darwin-static build-linux-static build-windows-static
 
+# The `run` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run`
+.PHONY: run
+run: docker-run
+
+# The `run-alter` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run-alter`
+.PHONY: run-alter
+run-alter: docker-run-alter
+
+# The `run-compress` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run-compress`
+.PHONY: run-compress
+run-compress: docker-run-compress
+
+# The `run-drop` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run-drop`
+.PHONY: run-drop
+run-drop: docker-run-drop
+
+# The `run-encrypt` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run-encrypt`
+.PHONY: run-encrypt
+run-encrypt: docker-run-encrypt
+
 # The `tidy` target is intended to clean up
 # the Go module files (go.mod & go.sum).
 #

--- a/migrations/v0.7/Makefile
+++ b/migrations/v0.7/Makefile
@@ -203,6 +203,7 @@ docker-run:
 	@echo
 	@echo "### Executing target/vela-migration:local image"
 	@docker run --rm \
+		-e VELA_ALL=true \
 		-e VELA_BUILD_LIMIT \
 		-e VELA_CONCURRENCY_LIMIT \
 		-e VELA_SECRET_LIMIT \
@@ -212,5 +213,79 @@ docker-run:
 		-e VELA_DATABASE_CONNECTION_IDLE \
 		-e VELA_DATABASE_CONNECTION_LIFE \
 		-e VELA_DATABASE_COMPRESSION_LEVEL \
+		-e VELA_DATABASE_ENCRYPTION_KEY \
+		target/vela-migration:local
+
+# The `docker-run-alter` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run-alter`
+.PHONY: docker-run-alter
+docker-run-alter:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_ALTER_TABLES=true \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
+		target/vela-migration:local
+
+# The `docker-run-compress` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run-compress`
+.PHONY: docker-run-compress
+docker-run-compress:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_COMPRESS_LOGS=true \
+		-e VELA_BUILD_LIMIT \
+		-e VELA_CONCURRENCY_LIMIT \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
+		-e VELA_DATABASE_COMPRESSION_LEVEL \
+		target/vela-migration:local
+
+# The `docker-run-drop` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run-drop`
+.PHONY: docker-run-drop
+docker-run-drop:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_DROP_INDEXES=true \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
+		target/vela-migration:local
+
+# The `docker-run-encrypt` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run-encrypt`
+.PHONY: docker-run-encrypt
+docker-run-encrypt:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_ENCRYPT_SECRETS=true \
+		-e VELA_SECRETS_LIMIT \
+		-e VELA_CONCURRENCY_LIMIT \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
 		-e VELA_DATABASE_ENCRYPTION_KEY \
 		target/vela-migration:local

--- a/migrations/v0.7/exec.go
+++ b/migrations/v0.7/exec.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+// Exec takes the provided configuration and attempts to
+// run a series of different functions that will
+// manipulate indexes, tables and columns.
+func (d *db) Exec(c *cli.Context) error {
+	logrus.Debug("executing workload from provided configuration")
+
+	// check if either the all or alter tables action was provided
+	if d.Actions.All || d.Actions.AlterTables {
+		// alter required tables in the database
+		err := d.Alter()
+		if err != nil {
+			return err
+		}
+	}
+
+	// check if either the all or drop indexes action was provided
+	if d.Actions.All || d.Actions.DropIndexes {
+		// drop unused indexes in the database
+		err := d.Drop()
+		if err != nil {
+			return err
+		}
+	}
+
+	// create new database service
+	err := d.New(c)
+	if err != nil {
+		return err
+	}
+
+	// check if either the all or compress logs action was provided
+	if d.Actions.All || d.Actions.CompressLogs {
+		// compress all log entries in the database
+		err = d.Compress()
+		if err != nil {
+			return err
+		}
+	}
+
+	// check if either the all or encrypt secrets action was provided
+	if d.Actions.All || d.Actions.EncryptSecrets {
+		// encrypt all secret values in the database
+		err = d.Encrypt()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/migrations/v0.7/main.go
+++ b/migrations/v0.7/main.go
@@ -42,23 +42,32 @@ func main() {
 
 	app.Flags = []cli.Flag{
 
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_BUILD_LIMIT", "BUILD_LIMIT"},
-			Name:    "build.limit",
-			Usage:   "sets the limit of build records to compress",
-			Value:   0,
+		// Action Flags
+
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_ALL"},
+			Name:    "all",
+			Usage:   "enables running all actions for v0.7.x",
 		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_CONCURRENCY_LIMIT", "CONCURRENCY_LIMIT"},
-			Name:    "concurrency.limit",
-			Usage:   "sets the number of concurrent processes running",
-			Value:   4,
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_ALTER_TABLES", "ALTER_TABLES"},
+			Name:    "alter.tables",
+			Usage:   "enables altering the table configuration for v0.7.x",
 		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_SECRET_LIMIT", "SECRET_LIMIT"},
-			Name:    "secret.limit",
-			Usage:   "sets the limit of secret records to encrypt",
-			Value:   0,
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_COMPRESS_LOGS", "COMPRESS_LOGS"},
+			Name:    "compress.logs",
+			Usage:   "enables compressing all logs for v0.7.x",
+		},
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_DROP_INDEXES", "DROP_INDEXES"},
+			Name:    "drop.indexes",
+			Usage:   "enables dropping unused indexes for v0.7.x",
+		},
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_ENCRYPT_SECRETS", "ENCRYPT_SECRETS"},
+			Name:    "encrypt.secrets",
+			Usage:   "enables encrypting secret values for v0.7.x",
 		},
 
 		// Database Flags
@@ -103,6 +112,27 @@ func main() {
 			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
 			Name:    "database.encryption.key",
 			Usage:   "AES-256 key for encrypting and decrypting values",
+		},
+
+		// Limit Flags
+
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_BUILD_LIMIT", "BUILD_LIMIT"},
+			Name:    "build.limit",
+			Usage:   "sets the limit of build records to compress",
+			Value:   0,
+		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_CONCURRENCY_LIMIT", "CONCURRENCY_LIMIT"},
+			Name:    "concurrency.limit",
+			Usage:   "sets the number of concurrent processes running",
+			Value:   4,
+		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_SECRET_LIMIT", "SECRET_LIMIT"},
+			Name:    "secret.limit",
+			Usage:   "sets the limit of secret records to encrypt",
+			Value:   0,
 		},
 
 		// Logger Flags

--- a/migrations/v0.7/main.go
+++ b/migrations/v0.7/main.go
@@ -76,13 +76,11 @@ func main() {
 			EnvVars: []string{"VELA_DATABASE_DRIVER", "DATABASE_DRIVER"},
 			Name:    "database.driver",
 			Usage:   "sets the driver to be used for the database",
-			Value:   "sqlite3",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_DATABASE_CONFIG", "DATABASE_CONFIG"},
 			Name:    "database.config",
 			Usage:   "sets the configuration string to be used for the database",
-			Value:   "vela.sqlite",
 		},
 		&cli.IntFlag{
 			EnvVars: []string{"VELA_DATABASE_CONNECTION_OPEN", "DATABASE_CONNECTION_OPEN"},

--- a/migrations/v0.7/run.go
+++ b/migrations/v0.7/run.go
@@ -52,6 +52,13 @@ func run(c *cli.Context) error {
 		CompressionLevel: c.Int("database.compression.level"),
 		ConcurrencyLimit: c.Int("concurrency.limit"),
 		SecretLimit:      c.Int("secret.limit"),
+		Actions: &actions{
+			All:            c.Bool("all"),
+			AlterTables:    c.Bool("alter.tables"),
+			CompressLogs:   c.Bool("compress.logs"),
+			DropIndexes:    c.Bool("drop.indexes"),
+			EncryptSecrets: c.Bool("encrypt.secrets"),
+		},
 		Connection: &connection{
 			Idle: c.Int("database.connection.open"),
 			Life: c.Duration("database.connection.idle"),

--- a/migrations/v0.7/validate.go
+++ b/migrations/v0.7/validate.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-vela/types/constants"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Validate verifies the provided database is configured properly.
+func (d *db) Validate() error {
+	logrus.Debug("validating provided database configuration")
+
+	// check if an action was provided
+	switch {
+	case d.Actions.AlterTables:
+		fallthrough
+	case d.Actions.CompressLogs:
+		fallthrough
+	case d.Actions.DropIndexes:
+		fallthrough
+	case d.Actions.EncryptSecrets:
+		fallthrough
+	case d.Actions.All:
+		break
+	default:
+		logrus.Warning("no vela-migration actions provided")
+	}
+
+	// check if the database driver is set
+	if len(d.Driver) == 0 {
+		return fmt.Errorf("VELA_DATABASE_DRIVER is not properly configured")
+	}
+
+	switch d.Driver {
+	case constants.DriverPostgres:
+		fallthrough
+	case constants.DriverSqlite:
+		break
+	default:
+		return fmt.Errorf("invalid VELA_DATABASE_DRIVER provided: %s", d.Driver)
+	}
+
+	// check if the database configuration is set
+	if len(d.Config) == 0 {
+		return fmt.Errorf("VELA_DATABASE_CONFIG is not properly configured")
+	}
+
+	// check if the database concurrency limit is set
+	if d.ConcurrencyLimit < 1 {
+		return fmt.Errorf("VELA_CONCURRENCY_LIMIT is not properly configured")
+	}
+
+	// check if either the all or compress logs action was provided
+	if d.Actions.All || d.Actions.CompressLogs {
+		// check if the database build limit is set
+		if d.BuildLimit < 0 {
+			return fmt.Errorf("VELA_BUILD_LIMIT is not properly configured")
+		}
+
+		// check if the compression level is valid
+		switch d.CompressionLevel {
+		case constants.CompressionNegOne:
+			fallthrough
+		case constants.CompressionZero:
+			fallthrough
+		case constants.CompressionOne:
+			fallthrough
+		case constants.CompressionTwo:
+			fallthrough
+		case constants.CompressionThree:
+			fallthrough
+		case constants.CompressionFour:
+			fallthrough
+		case constants.CompressionFive:
+			fallthrough
+		case constants.CompressionSix:
+			fallthrough
+		case constants.CompressionSeven:
+			fallthrough
+		case constants.CompressionEight:
+			fallthrough
+		case constants.CompressionNine:
+			break
+		default:
+			return fmt.Errorf("invalid level for VELA_DATABASE_COMPRESSION_LEVEL provided: %d", d.CompressionLevel)
+		}
+	}
+
+	// check if either the all or encrypt secrets action was provided
+	if d.Actions.All || d.Actions.EncryptSecrets {
+		// enforce AES-256, so check explicitly for 32 bytes on the key
+		//
+		// nolint: gomnd // ignore magic number
+		if len(d.EncryptionKey) != 32 {
+			return fmt.Errorf("invalid length for VELA_DATABASE_ENCRYPTION_KEY provided: %d", len(d.EncryptionKey))
+		}
+
+		// check if the database secret limit is set
+		if d.SecretLimit < 0 {
+			return fmt.Errorf("VELA_SECRET_LIMIT is not properly configured")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This enables the migration utility to invoke specific operations when trying to migrate to a `v0.7.x` release.

The following actions can be provided via their flag names:

* `all` - run all supported actions configured in the migration utility
* `alter.tables` - runs the action responsible for altering database tables
* `compress.logs` - runs the action responsible for compressing all logs
* `drop.indexes` - runs the action responsible for dropping unused indexes
* `encrypt.secrets` - runs the action responsible for encrypting secret values

Each of these actions can also be provided via environment variables:

* `VELA_ALL`
* `VELA_ALTER_TABLES` or `ALTER_TABLES`
* `VELA_COMPRESS_LOGS` or `COMPRESS_LOGS`
* `VELA_DROP_INDEXES` or `DROP_INDEXES`
* `VELA_ENCRYPT_SECRETS` or `ENCRYPT_SECRETS`