### PR TITLE
feat(v0.8): add logic to concurrently encrypt users

### DIFF
--- a/migrations/v0.8/DOCS.md
+++ b/migrations/v0.8/DOCS.md
@@ -62,6 +62,16 @@ This section covers the commands required to get the Vela application running lo
 cd $HOME/go-vela/community/migrations/v0.8
 ```
 
+* Set the environment variables for the other database configuration in your local terminal:
+
+```sh
+# sets the limit of concurrent processes used to operate on the database (default: 4)
+export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
+
+# set the key to encrypt user fields with AES-256
+export VELA_DATABASE_ENCRYPTION_KEY=<database encryption key from Vela server>
+```
+
 ### CLI
 
 This method of running the application uses the Golang binary built from the source code.
@@ -143,6 +153,7 @@ This utility supports invoking the following actions when migrating to `v0.8.x`:
 
 * `all` - run all supported actions configured in the migration utility
 * `alter.tables` - runs the action responsible for altering database tables
+* `encrypt.users` - runs the action responsible for encrypting user fields
 * `sync.counter` - runs the action responsible for syncing repo counter values
 
 ### Alter Tables
@@ -189,6 +200,65 @@ make run-alter
 #   -e VELA_DATABASE_CONNECTION_OPEN \
 #   -e VELA_DATABASE_CONNECTION_IDLE \
 #   -e VELA_DATABASE_CONNECTION_LIFE \
+#   target/vela-migration:local
+```
+
+### Encrypt Users
+
+* Set the environment variables for the other database configuration in your local terminal:
+
+```sh
+# sets the limit of concurrent processes used to operate on the database (default: 4)
+export VELA_CONCURRENCY_LIMIT=<range of 1 - runtime.GOMAXPROCS>
+
+# set the key to encrypt user fields with AES-256
+export VELA_DATABASE_ENCRYPTION_KEY=<database encryption key from Vela server>
+```
+
+#### CLI
+
+This method of running the application uses the Golang binary built from the source code.
+
+* Run the Golang binary for the specific operating system and architecture:
+
+```sh
+# run the Go binary for a Darwin (MacOS) operating system with amd64 architecture
+release/darwin/amd64/vela-migration --encrypt.users
+
+# run the Go binary for a Linux operating system with amd64 architecture
+release/linux/amd64/vela-migration --encrypt.users
+
+# run the Go binary for a Linux operating system with arm64 architecture
+release/linux/arm64/vela-migration --encrypt.users
+
+# run the Go binary for a Linux operating system with arm architecture
+release/linux/arm/vela-migration --encrypt.users
+
+# run the Go binary for a Windows operating system with amd64 architecture
+release/windows/amd64/vela-migration --encrypt.users
+```
+
+#### Docker
+
+This method of running the application uses a Docker container built from the `Dockerfile`.
+
+* Run the Docker image
+
+```sh
+# execute the `run-encrypt` target with `make`
+make run-encrypt
+
+# This command is functionally equivalent to:
+#
+# docker run --rm \
+#   -e VELA_ENCRYPT_USERS=true \
+#   -e VELA_CONCURRENCY_LIMIT \
+#   -e VELA_DATABASE_DRIVER \
+#   -e VELA_DATABASE_CONFIG \
+#   -e VELA_DATABASE_CONNECTION_OPEN \
+#   -e VELA_DATABASE_CONNECTION_IDLE \
+#   -e VELA_DATABASE_CONNECTION_LIFE \
+#   -e VELA_DATABASE_ENCRYPTION_KEY \
 #   target/vela-migration:local
 ```
 
@@ -244,5 +314,6 @@ make run-sync
 #   -e VELA_DATABASE_CONNECTION_OPEN \
 #   -e VELA_DATABASE_CONNECTION_IDLE \
 #   -e VELA_DATABASE_CONNECTION_LIFE \
+#   -e VELA_DATABASE_ENCRYPTION_KEY \
 #   target/vela-migration:local
 ```

--- a/migrations/v0.8/Makefile
+++ b/migrations/v0.8/Makefile
@@ -37,6 +37,13 @@ run: docker-run
 .PHONY: run-alter
 run-alter: docker-run-alter
 
+# The `run-encrypt` target is intended to build and
+# execute the Docker image for the utility.
+#
+# Usage: `make run-encrypt`
+.PHONY: run-encrypt
+run-encrypt: docker-run-encrypt
+
 # The `run-sync` target is intended to build and
 # execute the Docker image for the utility.
 #
@@ -231,6 +238,7 @@ docker-run:
 		-e VELA_DATABASE_CONNECTION_OPEN \
 		-e VELA_DATABASE_CONNECTION_IDLE \
 		-e VELA_DATABASE_CONNECTION_LIFE \
+		-e VELA_DATABASE_ENCRYPTION_KEY \
 		target/vela-migration:local
 
 # The `docker-run-alter` target is intended to execute
@@ -250,6 +258,25 @@ docker-run-alter:
 		-e VELA_DATABASE_CONNECTION_LIFE \
 		target/vela-migration:local
 
+# The `docker-run-encrypt` target is intended to execute
+# the Docker image for the utility.
+#
+# Usage: `make docker-run-encrypt`
+.PHONY: docker-run-encrypt
+docker-run-encrypt:
+	@echo
+	@echo "### Executing target/vela-migration:local image"
+	@docker run --rm \
+		-e VELA_ENCRYPT_USERS=true \
+		-e VELA_CONCURRENCY_LIMIT \
+		-e VELA_DATABASE_DRIVER \
+		-e VELA_DATABASE_CONFIG \
+		-e VELA_DATABASE_CONNECTION_OPEN \
+		-e VELA_DATABASE_CONNECTION_IDLE \
+		-e VELA_DATABASE_CONNECTION_LIFE \
+		-e VELA_DATABASE_ENCRYPTION_KEY \
+		target/vela-migration:local
+
 # The `docker-run-sync` target is intended to execute
 # the Docker image for the utility.
 #
@@ -266,4 +293,5 @@ docker-run-sync:
 		-e VELA_DATABASE_CONNECTION_OPEN \
 		-e VELA_DATABASE_CONNECTION_IDLE \
 		-e VELA_DATABASE_CONNECTION_LIFE \
+		-e VELA_DATABASE_ENCRYPTION_KEY \
 		target/vela-migration:local

--- a/migrations/v0.8/README.md
+++ b/migrations/v0.8/README.md
@@ -1,4 +1,4 @@
-# v0.7 migration
+# v0.8 migration
 
 > NOTE: This applies when upgrading to the latest `v0.8.x` release.
 
@@ -6,6 +6,9 @@ When migrating from Vela version [v0.7.4](../../releases/v0.7.4.md) to [v0.8.0](
 
 1. Updating tables in the database:
    * `ALTER TABLE repos ADD COLUMN IF NOT EXISTS counter INTEGER;`
+
+1. Encrypting the `hash`, `refresh_token` and `token` fields for all rows in the `users` table in the database:
+   * Use the `vela-migration` utility following [the documentation](DOCS.md).
 
 1. Syncing the build number `value` field for all rows in the `repos` table in the database:
    * Use the `vela-migration` utility following [the documentation](DOCS.md).
@@ -18,6 +21,7 @@ This utility supports invoking the following actions when migrating to `v0.8.x`:
 
 * `action.all` - run all supported actions (below) configured in the migration utility
 * `alter.tables` - runs the required queries to alter the database tables
+* `encrypt.users` - runs the required queries to encrypt the the `hash`, `refresh_token` and `token` fields for all rows in the `users` table
 * `sync.counter` - runs the required queries to grab the build number `value` field and update the repo counter for all rows in the `repos` table
 
 More information can be found in the [`DOCS.md` for the utility](DOCS.md).

--- a/migrations/v0.8/database.go
+++ b/migrations/v0.8/database.go
@@ -18,9 +18,10 @@ import (
 // actions represents all potential actions
 // this utility can invoke with the database.
 type actions struct {
-	All         bool
-	AlterTables bool
-	SyncCounter bool
+	All          bool
+	AlterTables  bool
+	EncryptUsers bool
+	SyncCounter  bool
 }
 
 // connection represents all connection related
@@ -36,14 +37,13 @@ type connection struct {
 // information used to communicate
 // with the database.
 type db struct {
-	Driver           string
-	Config           string
-	CompressionLevel int
+	Driver        string
+	Config        string
+	EncryptionKey string
 
 	Actions    *actions
 	Connection *connection
 
-	BuildLimit       int
 	ConcurrencyLimit int
 
 	Client database.Service

--- a/migrations/v0.8/encrypt.go
+++ b/migrations/v0.8/encrypt.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Encrypt attempts to capture all users from the database. The
+// function will then spawn the configured number of go routines
+// to begin processing the list of users concurrently. For each
+// user, the function will publish it to a channel all routines
+// are listening on to encrypt the user fields.
+func (d *db) Encrypt() error {
+	logrus.Debug("executing encrypt from provided configuration")
+
+	logrus.Info("capturing all users from the database")
+	// capture all users from the database
+	users, err := d.Client.GetUserList()
+	if err != nil {
+		return err
+	}
+
+	// create new error group to encrypt secret values concurrently
+	group := new(errgroup.Group)
+	// create new channel to process users concurrently
+	channel := make(chan *library.User)
+
+	// add set limit of routines to errgroup
+	// and begin processing secrets
+	for i := 0; i < d.ConcurrencyLimit; i++ {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := i
+
+		logrus.Infof("spawning go routine %d to listen on user channel", tmp)
+
+		// spawn a goroutine to begin encrypting user
+		// fields that are published to the channel
+		group.Go(func() error {
+			return d.EncryptUsers(tmp, channel)
+		})
+	}
+
+	// iterate through all users from the database
+	for _, user := range users {
+		logrus.Infof("publishing user %d to channel", user.GetID())
+
+		// publish the user to the channel
+		channel <- user
+
+		logrus.Debugf("user %d published to channel", user.GetID())
+	}
+
+	logrus.Debug("closing channel for publishing users")
+
+	// close channel to signal goroutines to stop processing
+	close(channel)
+
+	logrus.Debug("waiting for user go routines to complete")
+
+	return group.Wait()
+}
+
+// EncryptUsers will iterate over all users published to the
+// channel until the channel is closed. For each user published
+// to the channel the function will update the user with an
+// encrypted value.
+func (d *db) EncryptUsers(index int, channel chan *library.User) error {
+	logrus.Infof("go routine %d: listening on user channel", index)
+
+	// iterate through all users published to the channel
+	for u := range channel {
+		logrus.Infof("go routine %d: encrypting the value for user %d", index, u.GetID())
+
+		// update user with encryption in the database
+		err := d.Client.UpdateUser(u)
+		if err != nil {
+			return err
+		}
+
+		logrus.Tracef("go routine %d: value encrypted for user %d", index, u.GetID())
+	}
+
+	logrus.Infof("go routine %d: shutting down on user channel", index)
+
+	return nil
+}

--- a/migrations/v0.8/exec.go
+++ b/migrations/v0.8/exec.go
@@ -24,6 +24,15 @@ func (d *db) Exec(c *cli.Context) error {
 		}
 	}
 
+	// check if either the all or encrypt users action was provided
+	if d.Actions.All || d.Actions.EncryptUsers {
+		// encrypt user fields in the database
+		err := d.Encrypt()
+		if err != nil {
+			return err
+		}
+	}
+
 	// check if either the all or sync repo counter action was provided
 	if d.Actions.All || d.Actions.SyncCounter {
 		// sync all repo counter values in the database

--- a/migrations/v0.8/main.go
+++ b/migrations/v0.8/main.go
@@ -53,6 +53,11 @@ func main() {
 			Usage:   "enables altering the table configuration for v0.8.x",
 		},
 		&cli.BoolFlag{
+			EnvVars: []string{"VELA_ENCRYPT_USERS", "ENCRYPT_USERS"},
+			Name:    "encrypt.users",
+			Usage:   "enables encrypting user fields for v0.8.x",
+		},
+		&cli.BoolFlag{
 			EnvVars: []string{"VELA_SYNC_COUNTER", "SYNC_COUNTER"},
 			Name:    "sync.counter",
 			Usage:   "enables encrypting secret values for v0.8.x",
@@ -87,6 +92,11 @@ func main() {
 			Name:    "database.connection.life",
 			Usage:   "sets the amount of time a connection may be reused for the database",
 			Value:   30 * time.Minute,
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
+			Name:    "database.encryption.key",
+			Usage:   "AES-256 key for encrypting and decrypting values",
 		},
 
 		// Limit Flags

--- a/migrations/v0.8/run.go
+++ b/migrations/v0.8/run.go
@@ -47,13 +47,13 @@ func run(c *cli.Context) error {
 	d := &db{
 		Driver:           c.String("database.driver"),
 		Config:           c.String("database.config"),
-		BuildLimit:       c.Int("build.limit"),
-		CompressionLevel: c.Int("database.compression.level"),
 		ConcurrencyLimit: c.Int("concurrency.limit"),
+		EncryptionKey:    c.String("database.encryption.key"),
 		Actions: &actions{
-			All:         c.Bool("action.all"),
-			AlterTables: c.Bool("alter.tables"),
-			SyncCounter: c.Bool("sync.counter"),
+			All:          c.Bool("action.all"),
+			AlterTables:  c.Bool("alter.tables"),
+			EncryptUsers: c.Bool("encrypt.users"),
+			SyncCounter:  c.Bool("sync.counter"),
 		},
 		Connection: &connection{
 			Idle: c.Int("database.connection.open"),

--- a/migrations/v0.8/validate.go
+++ b/migrations/v0.8/validate.go
@@ -20,6 +20,8 @@ func (d *db) Validate() error {
 	switch {
 	case d.Actions.AlterTables:
 		fallthrough
+	case d.Actions.EncryptUsers:
+		fallthrough
 	case d.Actions.SyncCounter:
 		fallthrough
 	case d.Actions.All:
@@ -50,6 +52,16 @@ func (d *db) Validate() error {
 	// check if the database concurrency limit is set
 	if d.ConcurrencyLimit < 1 {
 		return fmt.Errorf("VELA_CONCURRENCY_LIMIT is not properly configured")
+	}
+
+	// check if either the all or encrypt users action was provided
+	if d.Actions.All || d.Actions.EncryptUsers {
+		// enforce AES-256, so check explicitly for 32 bytes on the key
+		//
+		// nolint: gomnd // ignore magic number
+		if len(d.EncryptionKey) != 32 {
+			return fmt.Errorf("invalid length for VELA_DATABASE_ENCRYPTION_KEY provided: %d", len(d.EncryptionKey))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/320

When upgrading to the latest release (`v0.8.x`), you'll have user fields stored in the database in an encrypted state.

To accomplish this, you'll be required to provide the encryption key to the utility.

This can be set via the existing flag `database.encryption.key` or environment variables:

* `VELA_DATABASE_ENCRYPTION_KEY`
* `DATABASE_ENCRYPTION_KEY`

This also enables the utility to concurrently encrypt user fields that are already stored in the database.

This can be set via the existing flag `concurrency.limit` or environment variables:

* `VELA_CONCURRENCY_LIMIT`
* `CONCURRENCY_LIMIT`

The default concurrency limit is still set to `4`.

This also has an added benefit of being able to "turn off" concurrency by passing a limit of `1`.
