### PR TITLE
chore(releases): add v0.8.0 release notes

### DIFF
--- a/releases/v0.8.0.md
+++ b/releases/v0.8.0.md
@@ -1,0 +1,57 @@
+# v0.8.0
+
+Thank you to everyone for trying Vela! This new release contains bug fixes, enhancements to existing features and new features!
+
+## Breaking Changes to Secrets
+
+Several consumers have experienced and reported issues when attempting to use multi-line secrets in Vela.
+
+In order to account for this gap in expected behavior, we've decided to take an opinionated approach of adapting Vela to these expectations.
+
+Going forward, after the secret has been read from the system, Vela will attempt to preserve newlines (`\n`) before injecting secrets into a container.
+
+## Features
+
+* enabling `services` to be used inside a Vela pipeline template
+* enabling `secrets` to be used inside a Vela pipeline template
+* allow incrementing the `counter` for a repository which controls the build number sequence
+* adding HTML input sanitization for data stored in Vela
+
+## Enhancements
+
+* encrypting sensitive fields in the `repos` database table
+* encrypting sensitive fields in the `users` database table
+* improve UI page title naming
+
+## Bug Fixes
+
+* enable running `steps` with the `comment` used in a `ruleset`
+* remove unset environment variables referencing the `finished` timestamp for a resource
+  * `BUILD_FINISHED`
+  * `VELA_BUILD_FINISHED`
+  * `VELA_SERVICE_FINISHED`
+  * `VELA_STEP_FINISHED`
+* prevent CLI from panicking when server is unreachable
+* preserve newlines (`\n`) in secret values before injecting into the container
+* CLI doesn't require secret `value` when updating an existing secret
+* populate `VELA_BUILD_ENQUEUED` environment variable
+* UI fields are right aligned in recent build history tool tip
+* use proper default values for UI timestamp fields in recent build history tool tip
+
+## For Vela Administrators
+
+* When upgrading from `v0.7`, please take note of the [migration information](/migrations/v0.8/README.md)
+
+## Full release notes available on [github.com/go-vela](https://github.com/go-vela)
+
+* [go-vela/ui](https://github.com/go-vela/ui/releases)
+* [go-vela/cli](https://github.com/go-vela/cli/releases)
+* [go-vela/server](https://github.com/go-vela/server/releases)
+* [go-vela/worker](https://github.com/go-vela/worker/releases)
+* [go-vela/types](https://github.com/go-vela/types/releases)
+* [go-vela/mock](https://github.com/go-vela/mock/releases)
+* [go-vela/compiler](https://github.com/go-vela/compiler/releases)
+* [go-vela/sdk-go](https://github.com/go-vela/sdk-go/releases)
+* [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime/releases)
+* [go-vela/pkg-executor](https://github.com/go-vela/pkg-executor/releases)
+* [go-vela/pkg-queue](https://github.com/go-vela/pkg-queue/releases)


### PR DESCRIPTION
This adds the release notes for the `v0.8.0` release