### PR TITLE
chore: tweak renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>go-vela/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": ["*"],
+      "excludePackagePatterns": ["^github.com/go-vela"]
+    }
   ]
 }


### PR DESCRIPTION
tweaking renovate bot with the goal of preventing PRs for `github.com/go-vela` dependencies.

in this repo, those dependencies are typically purposefully pinned at certain versions for compatibility.