### PR TITLE
chore(releases/v0.8): add v0.8.3 and v0.8.4 release notes

### DIFF
--- a/releases/v0.8.md
+++ b/releases/v0.8.md
@@ -20,6 +20,14 @@ This document contains all release notes pertaining to the `v0.8.x` releases of 
 * [go-vela/mock](https://github.com/go-vela/mock/releases)
 * [go-vela/types](https://github.com/go-vela/types/releases)
 
+## v0.8.4
+
+Thank you to everyone for trying Vela! This new release contains an important bug fix!
+
+### Bug Fixes
+
+* fix displaying `active` field for repos [go-vela/server#438](https://github.com/go-vela/server/pull/438)
+
 ## v0.8.3
 
 Thank you to everyone for trying Vela! This new release contains an enhancement and a very important bug fix!

--- a/releases/v0.8.md
+++ b/releases/v0.8.md
@@ -20,6 +20,18 @@ This document contains all release notes pertaining to the `v0.8.x` releases of 
 * [go-vela/mock](https://github.com/go-vela/mock/releases)
 * [go-vela/types](https://github.com/go-vela/types/releases)
 
+## v0.8.3
+
+Thank you to everyone for trying Vela! This new release contains an enhancement and a very important bug fix!
+
+### Enhancements
+
+* set commit status on canceled builds [go-vela/server#427](https://github.com/go-vela/server/pull/427)
+
+### Bug Fixes
+
+* updating secrets with empty fields [go-vela/server#433](https://github.com/go-vela/server/pull/433)
+
 ## v0.8.2
 
 Thank you to everyone for trying Vela! This new release contains a very important bug fix!


### PR DESCRIPTION
This adds the release notes for the `v0.8.3` and `v0.8.4` releases:

* [go-vela/server@v0.8.3](https://github.com/go-vela/server/releases/tag/v0.8.3)
* [go-vela/server@v0.8.4](https://github.com/go-vela/server/releases/tag/v0.8.4)