### PR TITLE
feat(releases): add release notes for v0.9.1

### DIFF
--- a/releases/v0.9.md
+++ b/releases/v0.9.md
@@ -20,6 +20,14 @@ This document contains all release notes pertaining to the `v0.9.x` releases of 
 * [go-vela/mock](https://github.com/go-vela/mock/releases)
 * [go-vela/types](https://github.com/go-vela/types/releases)
 
+## v0.9.1
+
+Thank you to everyone for trying Vela! This new release contains an important bug fix!
+
+### Bug Fixes
+
+* (server) **repo**: fix validation check for `pipeline_type` when creating repos ([#474](https://github.com/go-vela/server/issues/474))
+
 ## v0.9.0
 
 Thank you to everyone for trying Vela! This new release contains bug fixes, enhancements to existing features and new features!


### PR DESCRIPTION
This adds the release notes for the `v0.9.1` release for Vela