### PR TITLE
feat(proposals/2021): add information for repo structure

### DIFF
--- a/proposals/2021/07-22_log-streaming.md
+++ b/proposals/2021/07-22_log-streaming.md
@@ -15,7 +15,7 @@ The name of this markdown file should:
 | **Author(s)** | Jordan.Brockopp                                                                      |
 | **Reviewers** | Neal.Coleman, David.May, Emmanuel.Meinen, Kelly.Merrick, David.Vader, Matthew.Fevold |
 | **Date**      | July 22nd, 2021                                                                      |
-| **Status**    | Reviewed                                                                             |
+| **Status**    | Accepted                                                                             |
 
 <!--
 If you're already working with someone, please add them to the proper author/reviewer category.

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -172,7 +172,7 @@ This pattern repeats, for each group, until you get to the last group which has 
 
 With this structure, we simply have to create more releases (one per repo) than we would if we were to condense the repos.
 
-It also adds more complexity when releasing because you have to remember the order as well as ensure each repo has the latest dependencies.
+It also adds more complexity when releasing because you have to remember the order and ensure each repo has the latest dependencies.
 
 3. Are there any other workarounds, and if so, what are the drawbacks?
 

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -1,0 +1,233 @@
+# Repo Structure
+
+<!--
+The name of this markdown file should:
+
+1. Short and contain no more then 30 characters
+
+2. Contain the date of submission in MM-DD format
+
+3. Clearly state what the proposal is being submitted for
+-->
+
+| Key           | Value                                                                  |
+| :-----------: | :--------------------------------------------------------------------: |
+| **Author(s)** | Jordan.Brockopp                                                        |
+| **Reviewers** | David.May, Emmanuel.Meinen, Kelly.Merrick, David.Vader, Matthew.Fevold |
+| **Date**      | July 22nd, 2021                                                        |
+| **Status**    | Reviewed                                                               |
+
+<!--
+If you're already working with someone, please add them to the proper author/reviewer category.
+
+If not, please leave the reviewer category empty and someone from the Vela team will assign it to themself.
+
+Here is a brief explanation of the different proposal statuses:
+
+1. Reviewed: The proposal is currently under review or has been reviewed.
+
+2. Accepted: The proposal has been accepted and is ready for implementation.
+
+3. In Progress: An accepted proposal is being implemented by actual work.
+
+NOTE: The design is subject to change during this phase.
+
+4. Cancelled: While or before implementation the proposal was cancelled.
+
+NOTE: This can happen for a multitude of reasons.
+
+5. Complete: This feature/change is implemented.
+-->
+
+## Background
+
+<!--
+This section is intended to describe the new feature, redesign or refactor.
+-->
+
+**Please provide a summary of the new feature, redesign or refactor:**
+
+<!--
+Provide your description here.
+-->
+
+Currently, Vela has an inconsistent structure of how the "core" repos are setup within the [go-vela](https://github.com/go-vela) org.
+
+In this context, a "core" repo includes any repos that require code or dependency changes in order to release the Vela product.
+
+Today, we have the following "core" repos:
+
+* [cli](https://github.com/go-vela/cli)
+* [compiler](https://github.com/go-vela/compiler)
+* [mock](https://github.com/go-vela/mock)
+* [pkg-executor](https://github.com/go-vela/pkg-executor)
+* [pkg-queue](https://github.com/go-vela/pkg-queue)
+* [pkg-runtime](https://github.com/go-vela/pkg-runtime)
+* [sdk-go](https://github.com/go-vela/sdk-go)
+* [server](https://github.com/go-vela/server)
+* [types](https://github.com/go-vela/types)
+* [ui](https://github.com/go-vela/ui)
+* [worker](https://github.com/go-vela/worker)
+
+## Context
+
+Before attempting to propose any changes to this structure, it's important to provide context and clarity on why this structure exists.
+
+In the early beginnings of Vela, we thought that each individual capability/service/tool that Vela integrates with would get a unique repo.
+
+The naming convention for these repos would have the syntax of `pkg-<capability>` to denote the code housed in that repo.
+
+To provide an example with the current structure, we'll reference the [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo.
+
+Vela has to integrate with different runtime services or tools in order to execute workloads.
+
+So, the [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo contains all the code necessary to integrate with the different supported runtimes:
+
+* [docker](https://github.com/go-vela/pkg-runtime/tree/master/runtime/docker)
+* [kubernetes](https://github.com/go-vela/pkg-runtime/tree/master/runtime/kubernetes)
+
+Likewise for the [pkg-queue](https://github.com/go-vela/pkg-queue) repo, Vela has to integrate with different queue services or tools in order to schedule workloads.
+
+And the [pkg-queue](https://github.com/go-vela/pkg-queue) repo contains all the code necessary to integrate with the different supported queues:
+
+* [redis](https://github.com/go-vela/pkg-queue/tree/master/queue/redis)
+
+However, this structure has some problems, which are detailed below, that leave some room for improvement.
+
+**Please briefly answer the following questions:**
+
+1. Why is this required?
+
+<!-- Answer here -->
+
+This is not required so there is a lot of room for discussion on this.
+
+The intention or goal of this proposal is to accomplish the following:
+
+* condense and simplify the repo structure
+* improve consistency among the repos
+* ease the burden necessary to contribute bug fixes, new features and enhancements
+* reduce the level of overhead when attempting to publish new releases
+
+2. If this is a redesign or refactor, what issues exist in the current implementation?
+
+<!-- Answer here -->
+
+## Problem 1
+
+The first problem with this structure is ensuring consistency, both currently and going forward, among the repos in the [go-vela](https://github.com/go-vela) org.
+
+Currently, not all "core" repos follow the `pkg-<capability>` naming convention. i.e. [compiler](https://github.com/go-vela/compiler)
+
+Also, some "core" repos have the packages for different capabilities in the repo itself. i.e. [server](https://github.com/go-vela/server)
+
+If we plan to keep the `pkg-<capability>` structure, those should be pulled out into unique repos following that structure:
+
+* [pkg-database](https://github.com/go-vela/server/tree/master/database)
+* [pkg-secret](https://github.com/go-vela/server/tree/master/secret)
+* [pkg-source](https://github.com/go-vela/server/tree/master/source)
+
+## Problem 2
+
+The second problem with this structure is the increased burden, especially for new users, trying to contribute bug fixes, new features or enhancements.
+
+Some, or most, of the "core" repos have dependencies on one or more repos.
+
+This means that in order to make certain changes to the product, you have to introduce code changes to multiple repos.
+
+To provide an example with the current structure, we'll reference a newly added feature that allows you to customize the type of pipeline for a repo.
+
+This functionality was added as a part of [go-vela/community#326](https://github.com/go-vela/community/issues/326).
+
+To achieve this, a new `pipeline_type` field was added to the database which required code changes for multiple repos:
+
+* [types](https://github.com/go-vela/types/pull/188)
+* [compiler](https://github.com/go-vela/compiler/pull/199)
+* [server](https://github.com/go-vela/server/pull/444)
+* [ui](https://github.com/go-vela/ui/pull/421)
+
+This also increases the complexity when attempting to functionally test code changes.
+
+This is due to needing to modify each repo locally with the code changes for the functionality.
+
+Once that is complete, you then must build the application from the local code changes for each repo.
+
+## Problem 3
+
+The third problem with this structure is level of overhead when attempting to publish new releases for the product.
+
+The way the repos are setup today, there is a dependency tree that must be followed in order to properly release the product.
+
+The way the repos must be released is in groups that use the following order:
+
+1. [types](https://github.com/go-vela/types), [ui](https://github.com/go-vela/ui)
+2. [compiler](https://github.com/go-vela/compiler), [mock](https://github.com/go-vela/mock)
+3. [pkg-runtime](https://github.com/go-vela/pkg-runtime), [sdk-go](https://github.com/go-vela/sdk-go)
+4. [pkg-executor](https://github.com/go-vela/pkg-executor), [pkg-queue](https://github.com/go-vela/pkg-queue)
+5. [cli](https://github.com/go-vela/cli), [server](https://github.com/go-vela/server), [worker](https://github.com/go-vela/worker)
+
+After a release is completed for the first group, you must update the code dependencies for the second group before proceeding.
+
+This pattern repeats itself, for each group, until you get to the last group which has dependencies on most, if not all, of the preceding groups.
+
+With this structure, we simply have to create more releases (one per repo) than we would if we were to condense the repos.
+
+It also adds more complexity when releasing because you have to remember the order to release in as well as ensure each repo has the latest dependencies.
+
+3. Are there any other workarounds, and if so, what are the drawbacks?
+
+<!-- Answer here -->
+
+N/A
+
+4. Are there any related issues? Please provide them below if any exist.
+
+<!-- Answer here -->
+
+N/A
+
+## Design
+
+<!--
+This section is intended to explain the solution design for the proposal.
+
+NOTE: If there are no current plans for a solution, please leave this section blank.
+-->
+
+**Please describe your solution to the proposal. This includes, but is not limited to:**
+
+* new/updated endpoints or url paths
+* new/updated configuration variables (environment, flags, files, etc.)
+* performance and user experience tradeoffs
+* security concerns or assumptions
+* examples or (pseudo) code snippets
+
+<!-- Answer here -->
+
+## Implementation
+
+<!--
+This section is intended to explain how the solution will be implemented for the proposal.
+
+NOTE: If there are no current plans for implementation, please leave this section blank.
+-->
+
+**Please briefly answer the following questions:**
+
+1. Is this something you plan to implement yourself?
+
+<!-- Answer here -->
+
+2. What's the estimated time to completion?
+
+<!-- Answer here -->
+
+**Please provide all tasks (gists, issues, pull requests, etc.) completed to implement the design:**
+
+<!-- Answer here -->
+
+## Questions
+
+**Please list any questions you may have:**
+
+<!-- Answer here -->

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -55,7 +55,7 @@ Currently, Vela has an inconsistent structure of how the "core" repos are setup 
 
 In this context, a "core" repo includes any repos that require code or dependency changes in order to release the Vela product.
 
-Today, we have the following "core" repos:
+Today, we have the following "core" repos (`11` total):
 
 * [cli](https://github.com/go-vela/cli)
 * [compiler](https://github.com/go-vela/compiler)
@@ -228,7 +228,7 @@ To accomplish this, the following changes are proposed:
 7. Move the [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo
 
-In the end, the new "core" repo structure for the [go-vela](https://github.com/go-vela) org would look like:
+In the end, the new "core" repo structure for the [go-vela](https://github.com/go-vela) org would look like (`6` total):
 
 ```diff
 cli

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -14,7 +14,7 @@ The name of this markdown file should:
 | :-----------: | :--------------------------------------------------------------------: |
 | **Author(s)** | Jordan.Brockopp                                                        |
 | **Reviewers** | David.May, Emmanuel.Meinen, Kelly.Merrick, David.Vader, Matthew.Fevold |
-| **Date**      | July 22nd, 2021                                                        |
+| **Date**      | August 25th, 2021                                                      |
 | **Status**    | Reviewed                                                               |
 
 <!--
@@ -104,8 +104,8 @@ This is not required so there is a lot of room for discussion on this.
 
 The intention or goal of this proposal is to accomplish the following:
 
-* condense and simplify the repo structure
-* improve consistency among the repos
+* condense and simplify the "core" repo structure
+* improve consistency among the "core" repos
 * ease the burden necessary to contribute functionality to the product
 * reduce the level of overhead when attempting to publish new releases
 
@@ -204,6 +204,79 @@ NOTE: If there are no current plans for a solution, please leave this section bl
 
 <!-- Answer here -->
 
+The purpose of this proposal is to accomplish the following:
+
+* condense and simplify the "core" repo structure
+* improve consistency among the "core" repos
+* ease the burden necessary to contribute functionality to the product
+* reduce the level of overhead when attempting to publish new releases
+
+To accomplish this, the following changes are proposed:
+
+1. Move the [compiler](https://github.com/go-vela/compiler) repo into the [server](https://github.com/go-vela/server) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [compiler](https://github.com/go-vela/compiler) repo
+2. Move the [mock](https://github.com/go-vela/mock) repo into the [server](https://github.com/go-vela/server) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [mock](https://github.com/go-vela/mock) repo
+3. Move the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [server](https://github.com/go-vela/server) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [pkg-queue](https://github.com/go-vela/pkg-queue) repo
+4. Move the [mock](https://github.com/go-vela/mock) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [mock](https://github.com/go-vela/mock) repo
+5. Move the [pkg-executor](https://github.com/go-vela/pkg-executor) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [pkg-executor](https://github.com/go-vela/pkg-executor) repo
+6. Move the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [pkg-queue](https://github.com/go-vela/pkg-queue) repo
+7. Move the [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+   * Accompanying this, would be the deprecation and archiving of the existing [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo
+
+In the end, the new "core" repo structure for the [go-vela](https://github.com/go-vela) org would look like:
+
+```diff
+cli
+- compiler: moved -> server
+- mock: moved -> server/worker
+- pkg-executor: moved -> worker
+- pkg-queue: moved -> server/worker
+- pkg-runtime: moved -> worker
+sdk-go
+server
+types
+ui
+worker
+```
+
+The final directory structure for the [server](https://github.com/go-vela/server) would look like:
+
+```diff
+server
+ ├── api
+ ├── cmd
+ ├── compiler
+ ├── database
++├── mock
++├── queue
+ ├── random
+ ├── router
+ ├── secret
+ ├── source
+ ├── util
+ └── version
+```
+
+The final directory structure for the [worker](https://github.com/go-vela/worker) would look like:
+
+```diff
+worker
+ ├── api
+ ├── api-spec
+ ├── cmd
++├── executor
++├── mock
++├── queue
+ ├── router
++├── runtime
+ └── version
+```
+
 ## Implementation
 
 <!--
@@ -218,9 +291,13 @@ NOTE: If there are no current plans for implementation, please leave this sectio
 
 <!-- Answer here -->
 
+Yes
+
 2. What's the estimated time to completion?
 
 <!-- Answer here -->
+
+1 week
 
 **Please provide all tasks (gists, issues, pull requests, etc.) completed to implement the design:**
 
@@ -231,3 +308,5 @@ NOTE: If there are no current plans for implementation, please leave this sectio
 **Please list any questions you may have:**
 
 <!-- Answer here -->
+
+N/A

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -215,18 +215,26 @@ To accomplish this, the following changes are proposed:
 
 1. Move the [compiler](https://github.com/go-vela/compiler) repo into the [server](https://github.com/go-vela/server) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [compiler](https://github.com/go-vela/compiler) repo
-2. Move the [mock](https://github.com/go-vela/mock) repo into the [server](https://github.com/go-vela/server) repo as a nested package
+2. Move part of the [mock](https://github.com/go-vela/mock) repo into the [server](https://github.com/go-vela/server) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [mock](https://github.com/go-vela/mock) repo
-3. Move the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [server](https://github.com/go-vela/server) repo as a nested package
+3. Move part of the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [server](https://github.com/go-vela/server) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [pkg-queue](https://github.com/go-vela/pkg-queue) repo
-4. Move the [mock](https://github.com/go-vela/mock) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+4. Move part of the [mock](https://github.com/go-vela/mock) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [mock](https://github.com/go-vela/mock) repo
 5. Move the [pkg-executor](https://github.com/go-vela/pkg-executor) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [pkg-executor](https://github.com/go-vela/pkg-executor) repo
-6. Move the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
+6. Move part of the [pkg-queue](https://github.com/go-vela/pkg-queue) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [pkg-queue](https://github.com/go-vela/pkg-queue) repo
 7. Move the [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo into the [worker](https://github.com/go-vela/worker) repo as a nested package
    * Accompanying this, would be the deprecation and archiving of the existing [pkg-runtime](https://github.com/go-vela/pkg-runtime) repo
+
+> DISCLAIMER:
+>
+> Consideration was given to moving the [types](https://github.com/go-vela/types) repo into the [server](https://github.com/go-vela/server) and/or [worker](https://github.com/go-vela/worker).
+>
+> However, it was determined that may involve too much overhead and complicate things.
+>
+> The core concern for moving [types](https://github.com/go-vela/types) is the chance for causing circular dependencies.
 
 In the end, the new "core" repo structure for the [go-vela](https://github.com/go-vela) org would look like (`6` total):
 

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -239,17 +239,17 @@ To accomplish this, the following changes are proposed:
 In the end, the new "core" repo structure for the [go-vela](https://github.com/go-vela) org would look like (`6` total):
 
 ```diff
-cli
+1. cli
 - compiler: moved -> server
 - mock: moved -> server/worker
 - pkg-executor: moved -> worker
 - pkg-queue: moved -> server/worker
 - pkg-runtime: moved -> worker
-sdk-go
-server
-types
-ui
-worker
+2. sdk-go
+3. server
+4. types
+5. ui
+6. worker
 ```
 
 The final directory structure for the [server](https://github.com/go-vela/server) would look like:
@@ -258,7 +258,7 @@ The final directory structure for the [server](https://github.com/go-vela/server
 server
  ├── api
  ├── cmd
- ├── compiler
++├── compiler
  ├── database
 +├── mock
 +├── queue

--- a/proposals/2021/08-25_repo-structure.md
+++ b/proposals/2021/08-25_repo-structure.md
@@ -106,7 +106,7 @@ The intention or goal of this proposal is to accomplish the following:
 
 * condense and simplify the repo structure
 * improve consistency among the repos
-* ease the burden necessary to contribute bug fixes, new features and enhancements
+* ease the burden necessary to contribute functionality to the product
 * reduce the level of overhead when attempting to publish new releases
 
 2. If this is a redesign or refactor, what issues exist in the current implementation?
@@ -123,19 +123,19 @@ Also, some "core" repos have the packages for different capabilities in the repo
 
 If we plan to keep the `pkg-<capability>` structure, those should be pulled out into unique repos following that structure:
 
-* [pkg-database](https://github.com/go-vela/server/tree/master/database)
-* [pkg-secret](https://github.com/go-vela/server/tree/master/secret)
-* [pkg-source](https://github.com/go-vela/server/tree/master/source)
+* [server/database](https://github.com/go-vela/server/tree/master/database) -> `pkg-database`
+* [server/secret](https://github.com/go-vela/server/tree/master/secret) -> `pkg-secret`
+* [server/source](https://github.com/go-vela/server/tree/master/source) -> `pkg-source`
 
 ## Problem 2
 
-The second problem with this structure is the increased burden, especially for new users, trying to contribute bug fixes, new features or enhancements.
+The second problem with this structure is the increased burden, especially for new users, trying to contribute functionality.
 
 Some, or most, of the "core" repos have dependencies on one or more repos.
 
 This means that in order to make certain changes to the product, you have to introduce code changes to multiple repos.
 
-To provide an example with the current structure, we'll reference a newly added feature that allows you to customize the type of pipeline for a repo.
+To provide an example with the current structure, we'll reference a recent feature that allows you to customize the pipeline type for a repo.
 
 This functionality was added as a part of [go-vela/community#326](https://github.com/go-vela/community/issues/326).
 
@@ -146,11 +146,11 @@ To achieve this, a new `pipeline_type` field was added to the database which req
 * [server](https://github.com/go-vela/server/pull/444)
 * [ui](https://github.com/go-vela/ui/pull/421)
 
-This also increases the complexity when attempting to functionally test code changes.
+This also increases the complexity when attempting to functionally test code changes for new logic.
 
 This is due to needing to modify each repo locally with the code changes for the functionality.
 
-Once that is complete, you then must build the application from the local code changes for each repo.
+Once that is complete, the application must be rebuilt from the local code changes for each repo.
 
 ## Problem 3
 
@@ -168,11 +168,11 @@ The way the repos must be released is in groups that use the following order:
 
 After a release is completed for the first group, you must update the code dependencies for the second group before proceeding.
 
-This pattern repeats itself, for each group, until you get to the last group which has dependencies on most, if not all, of the preceding groups.
+This pattern repeats, for each group, until you get to the last group which has dependencies on most of the preceding groups.
 
 With this structure, we simply have to create more releases (one per repo) than we would if we were to condense the repos.
 
-It also adds more complexity when releasing because you have to remember the order to release in as well as ensure each repo has the latest dependencies.
+It also adds more complexity when releasing because you have to remember the order as well as ensure each repo has the latest dependencies.
 
 3. Are there any other workarounds, and if so, what are the drawbacks?
 

--- a/proposals/2021/README.md
+++ b/proposals/2021/README.md
@@ -5,3 +5,4 @@ This directory is meant to house a historical record of all potential features a
 ## Index
 
 * [07/22 Log Streaming](07-22_log-streaming.md): contains proposal information for streaming `logs` for `builds`
+* [08/25 Repo Structure](08-25_repo-structure.md): contains proposal information for condensing the repo structure for Vela

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -22,3 +22,4 @@ This directory is meant to house a historical record of all potential features a
 ### 2021
 
 * [07/22 Log Streaming](2021/07-22_log-streaming.md): contains proposal information for streaming `logs` for `builds`
+* [08/25 Repo Structure](2021/08-25_repo-structure.md): contains proposal information for condensing the repo structure for Vela


### PR DESCRIPTION
This proposes to condense the current repo structure in the [go-vela](https://github.com/go-vela) org.

Currently, we have `11` "core" repos for Vela.

After this proposal, we'd be left with `6` "core" repos for Vela.

> NOTE:
>
> In this context, a "core" repo is any repos that require code or dependency changes in order to release the product.

The intention of this proposal is to accomplish the following:

* condense and simplify the "core" repo structure
* improve consistency among the "core" repos
* ease the burden necessary to contribute functionality to the product
* reduce the level of overhead when attempting to publish new releases

The final structure for the "core" repos would look like:

```diff
1. cli
- compiler: moved -> server
- mock: moved -> server/worker
- pkg-executor: moved -> worker
- pkg-queue: moved -> server/worker
- pkg-runtime: moved -> worker
2. sdk-go
3. server
4. types
5. ui
6. worker
```