### PR TITLE
fix(v0.13.x): remove reverted feature

### DIFF
--- a/releases/v0.13.md
+++ b/releases/v0.13.md
@@ -58,7 +58,6 @@ Below is a summary of what's new in 0.13.0
 
 ### Features
 
-* (types) feat(repo): add last update field [235](https://github.com/go-vela/types/pull/235)
 * (types,server) feat: support stages with templates [237](https://github.com/go-vela/types/pull/237) [597](https://github.com/go-vela/server/pull/597)
 * (cli) feat: optional command line arguments for resources [328](https://github.com/go-vela/cli/pull/328)
 * (ui) feat: add key to secrets tables [528](https://github.com/go-vela/ui/pull/528)


### PR DESCRIPTION
the feature that is being removed from the release notes was reverted in https://github.com/go-vela/types/pull/241 which is part of v0.13.x release.