### PR TITLE
fix(releases/v0.13): show secrets syntax for breaking change

### DIFF
--- a/releases/v0.13.md
+++ b/releases/v0.13.md
@@ -43,7 +43,7 @@ Below is a summary of what's new in 0.13.0
 
     # Declarative repo secret definition.
     - name: foo
-      # syntax: <org>/<repo>/<name>
+      # syntax: <org>/<repo>/<secret name>
   +   key: github/octocat/foo
   +   engine: native
   +   type: repo

--- a/releases/v0.13.md
+++ b/releases/v0.13.md
@@ -43,10 +43,13 @@ Below is a summary of what's new in 0.13.0
 
     # Declarative repo secret definition.
     - name: foo
-  +   key: github/ocotocat/foo
+      # syntax: <org>/<repo>/<name>
+  +   key: github/octocat/foo
   +   engine: native
   +   type: repo
   ```
+  
+  Please see [our docs on the syntax for secrets](https://go-vela.github.io/docs/usage/secrets/#internal-secrets) to learn more information
 
 ### Bug Fixes
 


### PR DESCRIPTION
This updates the breaking change for secrets in the `v0.13` release notes.

Specifically, it adds a syntax example and links to the existing syntax examples in our docs.