### PR TITLE
fix(renovate): adjust config to exclude packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "packagePatterns": ["*"],
+      "matchPackagePatterns": ["*"],
       "excludePackagePatterns": ["^github.com/go-vela"]
     }
   ]


### PR DESCRIPTION
see https://docs.renovatebot.com/configuration-options/#excludepackagepatterns

we had a few PRs comes through that we had to manually close. this rule should have prevented that, but it looks like the configuration option has changed? or maybe it was always wrong.

as a reminder, this rule exists to prevent automatic updates for go-vela specific packages related to the migrations folder. those have to be pinned to specific vela versions for them to work.