### PR TITLE
fix(renovate): go-vela modules patch only, ignore dockerfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,11 @@
       "matchPackagePatterns": [
         "^github\\.com/go-vela/"
       ],
-      "matchUpdateTypes": [ "patch" ]
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
     }
   ],
   "dockerfile": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,8 +5,13 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": ["^github.com/go-vela"]
+      "matchPackagePatterns": [
+        "^github\\.com/go-vela/"
+      ],
+      "matchUpdateTypes": [ "patch" ]
     }
-  ]
+  ],
+  "dockerfile": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
this change should reduce PR noise here a bit on the /migrations folder via:
- limit github.com/go-vela/* modules to patch only; in /migrations, those are pinned intentionally and shouldn't be upgraded by minor/major version
- we use "latest" for dockerfile, pinning to digest is just noise; ignore dockerfiles