### PR TITLE
chore(release/v0.22): add v0.22 release notes

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,20 +1,23 @@
 # Migrations
 
-This directory is meant to house a historical record of migration documentation and utilities between versions.
+This directory is meant to house a historical record of migration documentation
+and utilities between versions.
 
 ## Index
 
-* [v0.7](./v0.7): contains information for migrating `v0.6.x` -> `v0.7.x`
-* [v0.8](./v0.8): contains information for migrating `v0.7.x` -> `v0.8.x`
-* [v0.9](./v0.9): contains information for migrating `v0.8.x` -> `v0.9.x`
-* [v0.10](./v0.10): no migration needed
-* [v0.11](./v0.11): no migration needed
-* [v0.12](./v0.12): contains information for migrating `v0.11.x` -> `v0.12.x`
-* [v0.13](./v0.13): contains information for migrating `v0.12.x` -> `v0.13.x`
-* [v0.14](./v0.14): contains information for migrating `v0.13.x` -> `v0.14.x`
-* [v0.15](./v0.15): contains information for migrating `v0.14.x` -> `v0.15.x`
-* [v0.16](./v0.16): contains information for migrating `v0.15.x` -> `v0.16.x`
-* [v0.17](./v0.17): contains information for migrating `v0.16.x` -> `v0.17.x`
-* [v0.18](./v0.18): contains information for migrating `v0.17.x` -> `v0.18.x`
-* [v0.19](./v0.19): contains information for migrating `v0.18.x` -> `v0.19.x`
-* [v0.20](./v0.20): contains information for migrating `v0.19.x` -> `v0.20.x`
+- [v0.7](./v0.7): contains information for migrating `v0.6.x` -> `v0.7.x`
+- [v0.8](./v0.8): contains information for migrating `v0.7.x` -> `v0.8.x`
+- [v0.9](./v0.9): contains information for migrating `v0.8.x` -> `v0.9.x`
+- [v0.10](./v0.10): no migration needed
+- [v0.11](./v0.11): no migration needed
+- [v0.12](./v0.12): contains information for migrating `v0.11.x` -> `v0.12.x`
+- [v0.13](./v0.13): contains information for migrating `v0.12.x` -> `v0.13.x`
+- [v0.14](./v0.14): contains information for migrating `v0.13.x` -> `v0.14.x`
+- [v0.15](./v0.15): contains information for migrating `v0.14.x` -> `v0.15.x`
+- [v0.16](./v0.16): contains information for migrating `v0.15.x` -> `v0.16.x`
+- [v0.17](./v0.17): contains information for migrating `v0.16.x` -> `v0.17.x`
+- [v0.18](./v0.18): contains information for migrating `v0.17.x` -> `v0.18.x`
+- [v0.19](./v0.19): contains information for migrating `v0.18.x` -> `v0.19.x`
+- [v0.20](./v0.20): contains information for migrating `v0.19.x` -> `v0.20.x`
+- [v0.21](./v0.21): contains information for migrating `v0.20.x` -> `v0.21.x`
+- [v0.22](./v0.22): no migration needed

--- a/migrations/v0.22/README.md
+++ b/migrations/v0.22/README.md
@@ -1,0 +1,3 @@
+# v0.22 migration
+
+No migration steps needed.

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,25 +1,28 @@
 # Releases
 
-This directory is meant to house a historical record of all features and modifications made to Vela.
+This directory is meant to house a historical record of all features and
+modifications made to Vela.
 
-Commonly referred to as release notes, these records will attempt to provide a brief overview of the changes made.
+Commonly referred to as release notes, these records will attempt to provide a
+brief overview of the changes made.
 
 ## Index
 
-* [v0.5](v0.5.md): contains release information for `v0.5.x`
-* [v0.6](v0.6.md): contains release information for `v0.6.x`
-* [v0.7](v0.7.md): contains release information for `v0.7.x`
-* [v0.8](v0.8.md): contains release information for `v0.8.x`
-* [v0.9](v0.9.md): contains release information for `v0.9.x`
-* [v0.10](v0.10.md): contains release information for `v0.10.x`
-* [v0.11](v0.11.md): contains release information for `v0.11.x`
-* [v0.12](v0.12.md): contains release information for `v0.12.x`
-* [v0.13](v0.13.md): contains release information for `v0.13.x`
-* [v0.14](v0.14.md): contains release information for `v0.14.x`
-* [v0.15](v0.15.md): contains release information for `v0.15.x`
-* [v0.16](v0.16.md): contains release information for `v0.16.x`
-* [v0.17](v0.17.md): contains release information for `v0.17.x`
-* [v0.18](v0.18.md): contains release information for `v0.18.x`
-* [v0.19](v0.19.md): contains release information for `v0.19.x`
-* [v0.20](v0.20.md): contains release information for `v0.20.x`
-* [v0.21](v0.21.md): contains release information for `v0.21.x`
+- [v0.5](v0.5.md): contains release information for `v0.5.x`
+- [v0.6](v0.6.md): contains release information for `v0.6.x`
+- [v0.7](v0.7.md): contains release information for `v0.7.x`
+- [v0.8](v0.8.md): contains release information for `v0.8.x`
+- [v0.9](v0.9.md): contains release information for `v0.9.x`
+- [v0.10](v0.10.md): contains release information for `v0.10.x`
+- [v0.11](v0.11.md): contains release information for `v0.11.x`
+- [v0.12](v0.12.md): contains release information for `v0.12.x`
+- [v0.13](v0.13.md): contains release information for `v0.13.x`
+- [v0.14](v0.14.md): contains release information for `v0.14.x`
+- [v0.15](v0.15.md): contains release information for `v0.15.x`
+- [v0.16](v0.16.md): contains release information for `v0.16.x`
+- [v0.17](v0.17.md): contains release information for `v0.17.x`
+- [v0.18](v0.18.md): contains release information for `v0.18.x`
+- [v0.19](v0.19.md): contains release information for `v0.19.x`
+- [v0.20](v0.20.md): contains release information for `v0.20.x`
+- [v0.21](v0.21.md): contains release information for `v0.21.x`
+- [v0.22](v0.22.md): contains release information for `v0.22.x`

--- a/releases/scripts/relgen.sh
+++ b/releases/scripts/relgen.sh
@@ -61,9 +61,9 @@ CONTRIBUTORS="$(perl -ne 'if(/\[(@[a-z0-9\[\]_-]+)\]\(/i) { print "- $1\n";}' "$
 # - only keep conventional commit formatted commits
 # - ignore dependency updates, reverts, and release commits
 cat "$RELEASE_FILE" |
-	grep --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+[a-z]+(\([a-z_[:space:]\-]+\))?!?:\s.+" |
+	grep --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+[a-z]+(\([a-z_[:space:]\-\/]+\))?!?:\s.+" |
 	grep --invert-match --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+(chore|fix)\(deps\)" |
-	grep --invert-match --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+revert(\([a-z\-_ ]+\))?:" |
+	grep --invert-match --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+revert(\([a-z\-_[:space:]\/]+\))?:" |
 	grep --invert-match --ignore-case --extended-regexp "^-\s+\([a-z\-]+\)\s+chore.*release" |
 	sponge "$RELEASE_FILE"
 

--- a/releases/v0.22.md
+++ b/releases/v0.22.md
@@ -1,0 +1,210 @@
+# v0.22 🚀
+
+This document contains all release notes pertaining to the `v0.22.x` releases of
+Vela.
+
+## v0.22.0
+
+We are excited to bring you v0.22.0 of Vela. This release is, at least in part,
+the result of a community hackathon and is comprised of the highlights below.
+Let us know what you think via issues or in our Slack channel!
+
+### 📣 Highlights
+
+- Auto-Canceling Builds
+- Build Pipeline Visualization
+- Improved Local Pipeline Execution Experience
+- Lazy Loading Secrets
+- Bug Fixes and other Enhancements
+
+### 💥 Breaking Changes
+
+#### Users:
+
+- (server) fix(router/scm)!: change HTTP method from GET to PATCH for sync
+  endpoints
+  [#994](https://github.com/go-vela/server/commit/e12a3dd81823cb6f4e5fc78bd19ddf7bbfb603d4) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+
+  - for Vela CLI users, make sure to upgrade to the latest version to ensure the
+    sync command functions properly. Of course, any API users will need to
+    adjust their HTTP verb accordingly.
+
+### ✨ Features
+
+- (server) feat: build graph endpoint for pipeline visualization
+  [#995](https://github.com/go-vela/server/commit/32bd680d1aad0b53554c8575dcfa3016fc21008a) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (server) feat(queue): add ping function for redis
+  [#991](https://github.com/go-vela/server/commit/6708cea79580d84437f93ea9755056ed330586b0) -
+  thanks [@timhuynh94](https://github.com/timhuynh94)!
+- (types) feat(yaml/secret): adding pull tag to secrets to create a lazy secrets
+  ability
+  [#312](https://github.com/go-vela/types/commit/19101a5b1346caaeb675fb5f7e5a100277381a88) -
+  thanks [@claire1618](https://github.com/claire1618)!
+- (ui) feat: build pipeline visualizer
+  [#731](https://github.com/go-vela/ui/commit/8cf3f88476c923a45043844c51f4d57b328903f0) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (worker) feat(executor/secrets): lazy loading secrets
+  [#526](https://github.com/go-vela/worker/commit/5ab220dfa56d3a61c7e4babdb4d70562a6659674) -
+  thanks [@claire1618](https://github.com/claire1618)!
+- (worker) feat: specify which privileged image is being pulled for denied build
+  [#530](https://github.com/go-vela/worker/commit/aafb6f9855966724b70f4d61837016b0e662b9af) -
+  thanks [@claire1618](https://github.com/claire1618)!
+
+### 🐛 Bug Fixes
+
+- (cli) fix(repo): do not have default value for branch
+  [#500](https://github.com/go-vela/cli/commit/661960440053b96b9b692272890b82fd54905fc4) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (sdk-go) fix(repo/sync): use PATCH over GET
+  [#270](https://github.com/go-vela/sdk-go/commit/457b799074a7843339054ea806938c4d4370e2de) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix(admin/clean): clean executable when build is cleaned
+  [#988](https://github.com/go-vela/server/commit/d90fdb7c11ad8613cd7be3939bbc38e9374264b1) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix(api/build): pop executable when pending build is auto canceled
+  [#990](https://github.com/go-vela/server/commit/7370602925b540642ad0f43b0c957ca180dea4b0) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix(api/schedule): early exit for empty name
+  [#996](https://github.com/go-vela/server/commit/3ee9ccfd892aa6d414ae1a6a95088af64386abdd) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix: attach metadata to build graph response
+  [#1003](https://github.com/go-vela/server/commit/65c06b572236685a9bf3abc043d6d21efa2f2e09) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (server) fix(compiler): return error on bad regular expressions that fail to
+  compile in Purge
+  [#985](https://github.com/go-vela/server/commit/bb35e76f6056131cac9961f131c6578339832548) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix(schedule): honor allow list for previously created schedules
+  [#998](https://github.com/go-vela/server/commit/a22bbad88237647f35c0d195339bc9be81acdd25) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) fix(scm): process reopened action for pull request event
+  [#1002](https://github.com/go-vela/server/commit/f1c58bd4ef9315d49466a956889f1e5c72b1f179) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (types) fix(log): add brackets to secret mask
+  [#333](https://github.com/go-vela/types/commit/e7d501937f4696a43769c6f9322381baf0a7ff44) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (types) fix(rulesets): surface error when regexp compilation fails + some
+  match code refactoring
+  [#327](https://github.com/go-vela/types/commit/0c0b890487aff7797a955c2e90248fbf0427ed8d) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (types) fix(schema): add schedule to the event options
+  [#330](https://github.com/go-vela/types/commit/c4fc61aa76198f45944f29a596d0db521cf1d4dc) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (types) fix(schema): use enum for secret pull policy
+  [#331](https://github.com/go-vela/types/commit/94c29dbe3fc74be842f3d9ae7f264b051804caf9) -
+  thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!
+- (types) fix(yaml): add reopened action to default pull_request unmarshal
+  [#332](https://github.com/go-vela/types/commit/ba41348d0fa9446f6b2d388130c8a114d841d386) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (ui) fix(graph): populate buildnumber on model
+  [#741](https://github.com/go-vela/ui/commit/e5a6e2aacf7a9e343b5e71e947593464b518e5f5) -
+  thanks [@wass3r](https://github.com/wass3r)!
+- (ui) fix(viz): apply overflow visible to root
+  [#739](https://github.com/go-vela/ui/commit/3c4fe3c5d3d32c5853b97291fd6657234a16ad5a) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (ui) fix(viz): flex style and overflow for small graphs
+  [#738](https://github.com/go-vela/ui/commit/c10f2a542e896c861a62fba15ef50981eb158dd4) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (ui) fix(viz): track draw state to apply recenter on fresh draws
+  [#740](https://github.com/go-vela/ui/commit/28779864016153a6e069a97cbd1e102be292c319) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (worker) fix(executor/local): do not override env with machine details for
+  local exec
+  [#522](https://github.com/go-vela/worker/commit/26628ba836f7dc881ec6c4fa36b2abb1bd3f29fe) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (worker) fix(secrets): isolate lazy secret loading
+  [#539](https://github.com/go-vela/worker/commit/29130e81be15a33eada5fefb4006a62f23112bf4) -
+  thanks [@wass3r](https://github.com/wass3r)!
+- (worker) fix(skip): surface error when failing to determine whether a
+  container should execute
+  [#524](https://github.com/go-vela/worker/commit/bcdf8e448bdfedb0b90b8e0e6da599b4c726a0ab) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (worker) fix(status): properly reflect worker status in db
+  [#525](https://github.com/go-vela/worker/commit/3249252744953ab50b53b7817af64e8b7467ded2) -
+  thanks [@timhuynh94](https://github.com/timhuynh94)!
+- (worker) fix(step): set step error for on_start failure using bad image
+  [#527](https://github.com/go-vela/worker/commit/6494030bc3ee3067bb97fdfd44be24167cf2c766) -
+  thanks [@timhuynh94](https://github.com/timhuynh94)!
+- (worker) fix: use build id to populate RunningBuildIDs
+  [#531](https://github.com/go-vela/worker/commit/7c34e60fdc0d2541a8cb3cca006a6f4262b832ce) -
+  thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!
+
+### 🚸 Enhancements
+
+- (cli) enhance(exec): templates and env support for exec pipeline
+  [#492](https://github.com/go-vela/cli/commit/ebb8068bbdcd2c3404f2e466e17e8fa7f6d9e12e) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (cli) enhance(pipeline/exec): include changeset for ruleset matching
+  [#495](https://github.com/go-vela/cli/commit/44e88965a38ea880e7e90bf3e560570668ee8200) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) enhance(api/webhook): update hook status to skipped when build is
+  skipped
+  [#993](https://github.com/go-vela/server/commit/262d7f096157bbd69663d7ac4ad72dc59df69f7b) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (server) enhance(compiler): environment and template adjustments for local
+  compilation
+  [#983](https://github.com/go-vela/server/commit/174ab52b94ffbd111653637e0ffde6e9b9d2b78d) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (ui) enhance(audit): parse skipped webhooks and show messaging
+  [#732](https://github.com/go-vela/ui/commit/9ba4e4321202e43e630a86f957726e8c9b999908) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (ui) enhance(audit): use established skip styling
+  [#734](https://github.com/go-vela/ui/commit/42b296a3e03c2120c9cae68a9dfcf579642e19eb) -
+  thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!
+- (ui) enhance(build): logic parsing and linking of auto cancel messaging
+  [#730](https://github.com/go-vela/ui/commit/607d3270a898c2e4b800c44780f1e38effa3a2e0) -
+  thanks [@ecrupper](https://github.com/ecrupper)!
+- (ui) enhance(cancel): improve msg label for cancel events
+  [#737](https://github.com/go-vela/ui/commit/b307868660c87efa9813473a3c19338e0a577d5d) -
+  thanks [@wass3r](https://github.com/wass3r)!
+
+### 🔧 Miscellaneous
+
+- (sdk-go) chore(lint): fix linter errors
+  [#268](https://github.com/go-vela/sdk-go/commit/d4124d46513d667c07661f0fc521a85683828d0b) -
+  thanks [@wass3r](https://github.com/wass3r)!
+- (server) chore: fixing code lint issues
+  [#999](https://github.com/go-vela/server/commit/542c244ca29094a1b4f1eb17666b03741ce91bb4) -
+  thanks [@plyr4](https://github.com/plyr4)!
+- (server) chore: updating types for lazy loading secrets
+  [#992](https://github.com/go-vela/server/commit/4eec5e9b03ab7e7004bfae08fc558eb2b27d87c5) -
+  thanks [@claire1618](https://github.com/claire1618)!
+- (worker) chore(docker): bump docker dependency
+  [#535](https://github.com/go-vela/worker/commit/73d6fdbeab1ec1a47389b8c98f31f1822943f805) -
+  thanks [@wass3r](https://github.com/wass3r)!
+- (sdk-go) test: update main to be default
+  [#267](https://github.com/go-vela/sdk-go/commit/393ca3262d597c937cf8eb4ba9149a6affd27470) -
+  thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+- (server) test: update main to be default
+  [#982](https://github.com/go-vela/server/commit/ae4356a307f4a000fe1511ff48025ac877fe894e) -
+  thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+- (types) test: update main to be default
+  [#324](https://github.com/go-vela/types/commit/9b2ca77fa0114782f075acb3122805c1b1d27e80) -
+  thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+- (ui) test(cypress): update main to be default
+  [#725](https://github.com/go-vela/ui/commit/fb659119e158e120d50e4d663c7b86eabe954ff4) -
+  thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+- (worker) test: update main to be default
+  [#521](https://github.com/go-vela/worker/commit/be492bd1e78717a54717c183983845be3234c236) -
+  thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+
+## 🔗 Release Links
+
+- https://github.com/go-vela/cli/releases
+- https://github.com/go-vela/sdk-go/releases
+- https://github.com/go-vela/server/releases
+- https://github.com/go-vela/types/releases
+- https://github.com/go-vela/ui/releases
+- https://github.com/go-vela/worker/releases
+
+## 💟 Thank you to all the contributors in this release!
+
+- @claire1618
+- @ecrupper
+- @KellyMerrick
+- @plyr4
+- @timhuynh94
+- @wass3r
+- @wass3rw3rk


### PR DESCRIPTION
- add v0.22 release notes
- small tweak to release script to account for commits with slashes in scope (for example, `fix(something/big): adjust hat radius`)

markdown linter/formatter apparently had its way a little bit here.