### PR TITLE
chore(release-notes): tweaks to v0.23.2 release notes

### DIFF
--- a/migrations/v0.23/README.md
+++ b/migrations/v0.23/README.md
@@ -25,3 +25,15 @@ administrator will want to ensure the following actions are being performed. All
 5. The `allow_events` column should be prepopulated using the SQL query in the migration script to ensure a smooth transition to the new system.
 
 6. `v0.23.x` (starting in v0.23.2) also adds an `allow_substitution` column to the secrets table to give more control on secret usage.
+
+## Recommended
+
+For increased security we recommend to set `allow_command` and `allow_substitution` to `false` for shared secrets in your secrets table. You can use the following SQL commands to do so:
+
+```sql
+UPDATE secrets SET allow_commands = false WHERE type = 'shared';
+```
+
+```sql
+UPDATE secrets SET allow_substitution = false WHERE type = 'shared';
+```

--- a/migrations/v0.23/README.md
+++ b/migrations/v0.23/README.md
@@ -23,3 +23,5 @@ administrator will want to ensure the following actions are being performed. All
   - https://github.com/go-vela/server/pull/1033
 
 5. The `allow_events` column should be prepopulated using the SQL query in the migration script to ensure a smooth transition to the new system.
+
+6. `v0.23.x` (starting in v0.23.2) also adds an `allow_substitution` column to the secrets table to give more control on secret usage.

--- a/migrations/v0.23/scripts/migration-postgres.sql
+++ b/migrations/v0.23/scripts/migration-postgres.sql
@@ -54,7 +54,12 @@ ALTER TABLE builds
 
 -- Add allow_events to secrets table
 ALTER TABLE secrets
-	ADD COLUMN IF NOT EXISTS allow_events INTEGER
+    ADD COLUMN IF NOT EXISTS allow_events INTEGER
+;
+
+-- Add allow_substitution to secrets table (part of v0.23.2)
+ALTER TABLE secrets
+    ADD COLUMN IF NOT EXISTS allow_substitution BOOLEAN
 ;
 
 /*

--- a/migrations/v0.23/scripts/migration-postgres.sql
+++ b/migrations/v0.23/scripts/migration-postgres.sql
@@ -93,3 +93,7 @@ UPDATE secrets
         (CASE WHEN events LIKE '%comment%' THEN 16384 | 32768 ELSE 0 END) |
         (CASE WHEN events LIKE '%schedule%' THEN 65536 ELSE 0 END)
 ;
+
+-- Match the field for the new allow_substitution setting with the existing allow_command setting
+UPDATE secrets SET allow_substitution = CASE WHEN allow_command = false THEN false ELSE true END;
+

--- a/migrations/v0.23/scripts/migration-sqlite.sql
+++ b/migrations/v0.23/scripts/migration-sqlite.sql
@@ -93,3 +93,6 @@ UPDATE secrets
         (CASE WHEN events LIKE '%comment%' THEN 16384 | 32768 ELSE 0 END) |
         (CASE WHEN events LIKE '%schedule%' THEN 65536 ELSE 0 END)
 ;
+
+-- Match the field for the new allow_substitution setting with the existing allow_command setting
+UPDATE secrets SET allow_substitution = CASE WHEN allow_command = false THEN false ELSE true END;

--- a/migrations/v0.23/scripts/migration-sqlite.sql
+++ b/migrations/v0.23/scripts/migration-sqlite.sql
@@ -54,7 +54,12 @@ ALTER TABLE builds
 
 -- Add allow_events to secrets table
 ALTER TABLE secrets
-	ADD COLUMN IF NOT EXISTS allow_events INTEGER
+    ADD COLUMN IF NOT EXISTS allow_events INTEGER
+;
+
+-- Add allow_substitution to secrets table (part of v0.23.2)
+ALTER TABLE secrets
+    ADD COLUMN IF NOT EXISTS allow_substitution BOOLEAN
 ;
 
 /*

--- a/releases/v0.23.md
+++ b/releases/v0.23.md
@@ -9,42 +9,17 @@ Vela.
 
 ## v0.23.2
 
-This new release is a security-focused release that addresses fixes for [CVE-2024-28236](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-28236).
-
-### 🔧 Miscellaneous
-
-- (cli) chore(shared secrets): add example using --team '*' for get shared secret [#533](https://github.com/go-vela/cli/commit/45bc445b6edb6e33fe7ad5aca3fb04a4234bd68f) - thanks [@KellyMerrick](https://github.com/KellyMerrick)!
+This new release is a security-focused release that addresses fixes for [CVE-2024-28236](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-28236) and updates Go to the latest 1.21.8 release which also includes some [CVE fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.21.8+label%3ACherryPickApproved) along with other dependency updates.
 
 ### 🚸 Enhancements
 
-- (cli) enhance(repo): update validation to include first-time option [#535](https://github.com/go-vela/cli/commit/00bbc8f12f9c05365a208a5881d612aea85168e9) - thanks [@ecrupper](https://github.com/ecrupper)!
 - (server) enhance(ci): keep clone image updated via renovate [#1072](https://github.com/go-vela/server/commit/07949d4f16c6e6f09630dd73019a129b99448623) - thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!
-- (ui) enhance(repo-settings): add first-time contributor approval option [#768](https://github.com/go-vela/ui/commit/8ddb96f522998037e038436c32460dbc3badda1d) - thanks [@ecrupper](https://github.com/ecrupper)!
 
 ### 🐛 Bug Fixes
 
 - (cli) fix(pipeline): always set local to true for validate local [#534](https://github.com/go-vela/cli/commit/db6080d60fb9c232d70f41418a220c65ac678857) - thanks [@ecrupper](https://github.com/ecrupper)!
 - (server) fix(build-approval): correct approved_by and disallow self-approval [#1075](https://github.com/go-vela/server/commit/4a26eb417b62d47548e8319368c7e74a7f748c0d) - thanks [@ecrupper](https://github.com/ecrupper)!
 - (server) fix(renovate): add datasourceTemplate [#1074](https://github.com/go-vela/server/commit/0563995ec903dcb9de81f30ab52c8a08701fea9a) - thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!
-- (ui) fix: add missing approved by info and link PR commit [#769](https://github.com/go-vela/ui/commit/d42df7673f302202f58e8a3bbbdb39989a792d6b) - thanks [@wass3r](https://github.com/wass3r)!
-
-### 🔗 Release Links
-
-- https://github.com/go-vela/cli/releases
-- https://github.com/go-vela/sdk-go/releases
-- https://github.com/go-vela/server/releases
-- https://github.com/go-vela/types/releases
-- https://github.com/go-vela/ui/releases
-- https://github.com/go-vela/worker/releases
-
-### 💟 Thank you to all the contributors in this release!
-
-- @dependabot[bot]
-- @ecrupper
-- @KellyMerrick
-- @renovate[bot]
-- @wass3r
-- @wass3rw3rk
 
 ## v0.23.1
 

--- a/releases/v0.23.md
+++ b/releases/v0.23.md
@@ -11,6 +11,8 @@ Vela.
 
 This new release is a security-focused release that addresses fixes for [CVE-2024-28236](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-28236) and updates Go to the latest 1.21.8 release which also includes some [CVE fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.21.8+label%3ACherryPickApproved) along with other dependency updates.
 
+Vela Administrators: the [migration information](/migrations/v0.23/README.md) has been updated, please re-review for this patch release.
+
 ### 🚸 Enhancements
 
 - (server) enhance(ci): keep clone image updated via renovate [#1072](https://github.com/go-vela/server/commit/07949d4f16c6e6f09630dd73019a129b99448623) - thanks [@wass3rw3rk](https://github.com/wass3rw3rk)!


### PR DESCRIPTION
remove commits that belonged to v0.23.1 from new v0.23.2 section. call out other CVEs being addressed. update migration script to account for new column in secrets table.