### PR TITLE
fix(migrations/v0.23): allow_commands -> allow_command

### DIFF
--- a/migrations/v0.23/README.md
+++ b/migrations/v0.23/README.md
@@ -37,7 +37,7 @@ For existing native secrets, please follow the provided DML query in the migrati
 For increased security we recommend to set `allow_command` and `allow_substitution` to `false` for shared secrets in your secrets table. You can use the following SQL commands to do so:
 
 ```sql
-UPDATE secrets SET allow_commands = false WHERE type = 'shared';
+UPDATE secrets SET allow_command = false WHERE type = 'shared';
 ```
 
 ```sql


### PR DESCRIPTION
This change resolves an issue when attempting to run the recommended SQL queries for the `v0.23` migration:

https://github.com/go-vela/community/tree/main/migrations/v0.23#recommended

The fix is to update the first recommended SQL query from:

```sql
UPDATE secrets SET allow_commands = false WHERE type = 'shared';
```

to:

```sql
UPDATE secrets SET allow_command = false WHERE type = 'shared';
```

When attempting to follow the docs in their current state, I was met with this output from Postgres:

```sql
vela=> UPDATE secrets SET allow_commands = false WHERE type = 'shared';
ERROR:  column "allow_commands" of relation "secrets" does not exist
LINE 1: UPDATE secrets SET allow_commands = false WHERE type = 'shar...
```